### PR TITLE
Add MirrorPeerSecret controller

### DIFF
--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -101,6 +101,13 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - ""
+          resources:
+          - events
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
           - multicluster.odf.openshift.io
           resources:
           - mirrorpeers

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,6 +67,13 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - events
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
   - multicluster.odf.openshift.io
   resources:
   - mirrorpeers

--- a/controllers/common-controller-utils.go
+++ b/controllers/common-controller-utils.go
@@ -1,0 +1,270 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/common"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func fetchAllMirrorPeers(ctx context.Context, rc client.Client) ([]multiclusterv1alpha1.MirrorPeer, error) {
+	var mirrorPeerListObj multiclusterv1alpha1.MirrorPeerList
+	err := rc.List(ctx, &mirrorPeerListObj)
+	if err != nil {
+		return nil, err
+	}
+	return mirrorPeerListObj.Items, nil
+}
+
+// createOrUpdateDestinationSecretsFromSource updates all destination secrets
+// associated with this source secret.
+// If a list of MirrorPeer objects are provided, it will check
+// the mapping from the provided MirrorPeers.
+// If no MirrorPeers are provided, it will fetch all the MirrorPeers in the HUB.
+func createOrUpdateDestinationSecretsFromSource(ctx context.Context, rc client.Client, sourceSecret *corev1.Secret, mirrorPeers ...multiclusterv1alpha1.MirrorPeer) error {
+	logger := log.FromContext(ctx)
+	err := common.ValidateSourceSecret(sourceSecret)
+	if err != nil {
+		logger.Error(err, "Updating secrets failed. Invalid secret type.", "secret", sourceSecret)
+		return err
+	}
+
+	if mirrorPeers == nil {
+		mirrorPeers, err = fetchAllMirrorPeers(ctx, rc)
+		if err != nil {
+			logger.Error(err, "Unable to get the list of MirrorPeer objects")
+			return err
+		}
+		logger.V(2).Info("Successfully got the list of MirrorPeers", "MirrorPeerListObj", mirrorPeers)
+	}
+
+	uniqueConnectedPeers, err := PeersConnectedToSecret(sourceSecret, mirrorPeers)
+	if err != nil {
+		logger.Error(err, "ConnectedPeers returned an error", "secret", sourceSecret, "mirrorpeers", mirrorPeers)
+		return err
+	}
+	logger.V(2).Info("Listing all the Peers connected to the Source", "SourceSecret", sourceSecret, "#connected-peers", len(uniqueConnectedPeers))
+
+	// anyErr will have the last found error
+	var anyErr error
+	for _, eachConnectedPeer := range uniqueConnectedPeers {
+		namedPeerRef := NewNamedPeerRefWithSecretData(sourceSecret, eachConnectedPeer)
+		err := namedPeerRef.CreateOrUpdateDestinationSecret(ctx, rc)
+		if err != nil {
+			logger.Error(err, "Unable to update the destination secret", "PeerRef", eachConnectedPeer)
+			anyErr = err
+		}
+	}
+
+	return anyErr
+}
+
+func processDestinationSecretUpdation(ctx context.Context, rc client.Client, destSecret *corev1.Secret) error {
+	logger := log.FromContext(ctx)
+	err := common.ValidateDestinationSecret(destSecret)
+	if err != nil {
+		logger.Error(err, "Destination secret validation failed", "secret", destSecret)
+		return err
+	}
+	mirrorPeers, err := fetchAllMirrorPeers(ctx, rc)
+	if err != nil {
+		logger.Error(err, "Failed to get the list of MirrorPeer objects")
+		return err
+	}
+	uniqueConnectedPeers, err := PeersConnectedToSecret(destSecret, mirrorPeers)
+	if err != nil {
+		logger.Error(err, "Failed to get the peers connected to the secret", "secret", destSecret)
+		return err
+	}
+	var connectedSource *corev1.Secret
+	for _, eachConnectedPeer := range uniqueConnectedPeers {
+		var connectedSecret corev1.Secret
+		nPeerRef := NewNamedPeerRefWithSecretData(destSecret, eachConnectedPeer)
+		err := nPeerRef.GetAssociatedSecret(ctx, rc, &connectedSecret)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			logger.Error(err, "Unexpected error while finding the source secret", "peer-ref", eachConnectedPeer, "secret", destSecret)
+			return err
+		}
+		if common.IsSecretSource(&connectedSecret) {
+			connectedSource = connectedSecret.DeepCopy()
+			break
+		}
+	}
+
+	if connectedSource == nil {
+		logger.Error(nil, "No connected source found. Removing the dangling destination secret", "secret", destSecret)
+		err = rc.Delete(ctx, destSecret)
+		return err
+	}
+	err = createOrUpdateDestinationSecretsFromSource(ctx, rc, connectedSource, mirrorPeers...)
+	return err
+}
+
+// processDeletedSecrets finds out which type of secret is deleted
+// and do appropriate action
+func processDeletedSecrets(ctx context.Context, rc client.Client, req types.NamespacedName) error {
+	var err error
+	logger := log.FromContext(ctx, "controller", "MirrorPeerController")
+	// get all the secrets with the same name
+	var secretList corev1.SecretList
+	var hasLabel client.HasLabels = []string{common.SecretLabelTypeKey}
+	err = rc.List(ctx, &secretList, &hasLabel)
+	if err != nil {
+		logger.Error(err, "Unable to get the list of secrets")
+		return err
+	}
+	// sameNamedDestinationSecrets will collect the same named destination secrets
+	var sameNamedDestinationSecrets []corev1.Secret
+	// sourceSecretPointer will point to the source secret
+	var sourceSecretPointer *corev1.Secret
+	// append all the secrets which have the same requested name
+	for _, eachSecret := range secretList.Items {
+		if eachSecret.Name == req.Name {
+			// check similarly named secret is present (or not)
+			if secretType := eachSecret.Labels[common.SecretLabelTypeKey]; secretType == string(common.SourceLabel) {
+				// if 'sourceSecretPointer' already points to a source secret,
+				// it is an error. We should not have TWO source
+				// secrets of same name.
+				if sourceSecretPointer != nil {
+					err = errors.New("multiple source secrets detected")
+					logger.Error(err, "Cannot have more than one source secrets with the same name", "request", req, "source-secret", *sourceSecretPointer)
+					return err
+				}
+				sourceSecretPointer = eachSecret.DeepCopy()
+			} else {
+				sameNamedDestinationSecrets = append(sameNamedDestinationSecrets, eachSecret)
+			}
+		}
+	}
+
+	logger.V(2).Info("List of secrets with requested name", "secret-name", req.Name, "secretlist", sameNamedDestinationSecrets, "#secrets", len(sameNamedDestinationSecrets))
+
+	if sourceSecretPointer == nil {
+		// if there is neither source secret nor any other similarly named secrets,
+		// that means all 'req.Name'-ed secrets are cleaned up and nothing to be done
+		if len(sameNamedDestinationSecrets) == 0 {
+			return nil
+		}
+		logger.Info("A SOURCE secret deletion detected", "secret-name", req.Name)
+		var anyErr error
+		// if source secret is not present, remove all the destinations|GREENs
+		for _, eachDestSecret := range sameNamedDestinationSecrets {
+			err = rc.Delete(ctx, &eachDestSecret)
+			if err != nil {
+				logger.Error(err, "Deletion failed", "secret", eachDestSecret)
+				anyErr = err
+			}
+		}
+		// if any error has happened,
+		// we will return the last found error
+		if anyErr != nil {
+			return anyErr
+		}
+	} else {
+		logger.Info("A DESTINATION secret deletion detected", "secret-name", req.Name)
+		// in this section, one of the destination is removed
+		// action: use the source secret pointed by 'sourceSecretPointer'
+		// and restore the missing destination secret
+		allMirrorPeers, err := fetchAllMirrorPeers(ctx, rc)
+		if err != nil {
+			return err
+		}
+		var destPeerPointer *multiclusterv1alpha1.PeerRef
+		uniqueConnectedPeers, err := PeersConnectedToSecret(sourceSecretPointer, allMirrorPeers)
+		if err != nil {
+			logger.Error(err, "ConnectedPeer returned an error", "secret", sourceSecretPointer, "mirrorpeers", allMirrorPeers)
+			return err
+		}
+
+		for _, eachPeer := range uniqueConnectedPeers {
+			// compare the 'ClusterName' and requested 'Namespace'
+			// as the managed cluster name will be mapped to a
+			// namespace in HUB
+			if eachPeer.ClusterName == req.Namespace {
+				// break from the loop, as we found the PeerRef
+				// matching the destination 'namespace'
+				// PS: there will be only ONE destination
+				// (in a namespace) corresponding to a source
+				destPeerPointer = eachPeer.DeepCopy()
+				break
+			}
+		}
+		// check if we didn't find a mapping destination Peer
+		if destPeerPointer == nil {
+			// most probably source is deleted or connection in MirrorPeer CR has reset
+			// since 'logger' don't have a WARNING, printing this as an error,
+			// even though we are not returning any error
+			logger.Error(nil, "No Peers found for the provided request", "request", req, "source-secret", sourceSecretPointer, "existing-peers", uniqueConnectedPeers, "all-mirrorpeer-objs", allMirrorPeers)
+			return nil
+		}
+		namedPeerRef := NewNamedPeerRefWithSecretData(sourceSecretPointer, *destPeerPointer)
+		err = namedPeerRef.CreateOrUpdateDestinationSecret(ctx, rc)
+		if err != nil {
+			logger.Error(err, "Unable to update the destination secret", "PeerRef", *destPeerPointer)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// peersConnectedFromPeerRefList returns all the peers associated with the source peer item
+func peersConnectedFromPeerRefList(sourcePeerRef multiclusterv1alpha1.PeerRef, allPeerItems []multiclusterv1alpha1.PeerRef) []multiclusterv1alpha1.PeerRef {
+	var connectedPeers []multiclusterv1alpha1.PeerRef
+	var itemsContainsSource bool
+	for _, eachPeerRef := range allPeerItems {
+		// checks whether the provided 'sourcePeerItem' is in the list
+		if reflect.DeepEqual(sourcePeerRef, eachPeerRef) {
+			itemsContainsSource = true
+			continue
+		}
+		connectedPeers = append(connectedPeers, eachPeerRef)
+	}
+	// when the source PeerRef is in the list,
+	// then only return the 'connectedPeers'
+	if itemsContainsSource {
+		return connectedPeers
+	}
+	return nil
+}
+
+// PeersConnectedToPeerRef returns a list of PeerRefs connected to the 'sourcePeerRef'.
+func PeersConnectedToPeerRef(sourcePeerRef multiclusterv1alpha1.PeerRef, mirrorPeers []multiclusterv1alpha1.MirrorPeer) []multiclusterv1alpha1.PeerRef {
+	uniquePeerRefMap := make(map[string]multiclusterv1alpha1.PeerRef)
+	for _, eachMirrorPeerObj := range mirrorPeers {
+		connectedPeers := peersConnectedFromPeerRefList(sourcePeerRef, eachMirrorPeerObj.Spec.Items)
+		if len(connectedPeers) > 0 {
+			// add the PeerRef s into a map, to keep only the unique ones
+			for _, eachPeerRef := range connectedPeers {
+				mapKey := common.CreateUniqueName(eachPeerRef.ClusterName, eachPeerRef.StorageClusterRef.Namespace, eachPeerRef.StorageClusterRef.Name)
+				uniquePeerRefMap[mapKey] = eachPeerRef
+			}
+		}
+	}
+	// extract the unique 'PeerRef' s
+	var uniquePeerRefs []multiclusterv1alpha1.PeerRef
+	for _, eachPeerRef := range uniquePeerRefMap {
+		uniquePeerRefs = append(uniquePeerRefs, eachPeerRef)
+	}
+	return uniquePeerRefs
+}
+
+// PeersConnectedToSecret return unique PeerRefs associated with the secret
+func PeersConnectedToSecret(secret *corev1.Secret, mirrorPeers []multiclusterv1alpha1.MirrorPeer) ([]multiclusterv1alpha1.PeerRef, error) {
+	// create a PeerRef object from the given source secret
+	sourcePeerRef, err := common.CreatePeerRefFromSecret(secret)
+	if err != nil {
+		return nil, err
+	}
+	return PeersConnectedToPeerRef(sourcePeerRef, mirrorPeers), nil
+}

--- a/controllers/common/secret-utils.go
+++ b/controllers/common/secret-utils.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha512"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
@@ -169,4 +170,20 @@ func CreatePeerRefFromSecret(secret *corev1.Secret) (multiclusterv1alpha1.PeerRe
 			Namespace: string(secret.Data[NamespaceKey])},
 	}
 	return retPeerRef, nil
+}
+
+func FindMatchingSecretWithPeerRef(peerRef multiclusterv1alpha1.PeerRef, secrets []corev1.Secret) *corev1.Secret {
+	var matchingSourceSecret *corev1.Secret
+	for _, eachSecret := range secrets {
+		secretPeerRef, err := CreatePeerRefFromSecret(&eachSecret)
+		// ignore any error and continue with the next
+		if err != nil {
+			continue
+		}
+		if reflect.DeepEqual(secretPeerRef, peerRef) {
+			matchingSourceSecret = &eachSecret
+			break
+		}
+	}
+	return matchingSourceSecret
 }

--- a/controllers/common/secret-utils.go
+++ b/controllers/common/secret-utils.go
@@ -1,0 +1,172 @@
+package common
+
+import (
+	"crypto/sha512"
+	"errors"
+	"fmt"
+	"strings"
+
+	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type SecretLabelType string
+
+const (
+	SourceLabel           SecretLabelType = "BLUE"
+	DestinationLabel      SecretLabelType = "GREEN"
+	InternalLabel         SecretLabelType = "INTERNAL"
+	IgnoreLabel           SecretLabelType = "IGNORE"
+	SecretLabelTypeKey                    = "multicluster.odf.openshift.io/secret-type"
+	NamespaceKey                          = "namespace"
+	StorageClusterNameKey                 = "storage-cluster-name"
+	SecretDataKey                         = "secret-data"
+)
+
+var (
+	SourceOrDestinationPredicate = predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return IsSecretSource(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return IsSecretSource(e.Object) || IsSecretDestination(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return (IsSecretSource(e.ObjectOld) && IsSecretSource(e.ObjectNew)) ||
+				(IsSecretDestination(e.ObjectOld) && IsSecretDestination(e.ObjectNew))
+		},
+		GenericFunc: func(_ event.GenericEvent) bool {
+			return false
+		},
+	}
+)
+
+func GetInternalLabel(secret *corev1.Secret) SecretLabelType {
+	return SecretLabelType(secret.Labels[SecretLabelTypeKey])
+}
+
+func isObjectASecretWithProvidedLabel(obj client.Object, label, value string) bool {
+	sec, ok := obj.(*corev1.Secret)
+	if !ok {
+		return false
+	}
+	lblVal, ok := sec.Labels[label]
+	// if 'ok' (ie; if provided label key is present) AND values match,
+	// then return true
+	return ok && (lblVal == value)
+}
+
+// IsSecretSource returns true if the provided object is a secret with Source label
+func IsSecretSource(obj client.Object) bool {
+	return isObjectASecretWithProvidedLabel(obj, SecretLabelTypeKey, string(SourceLabel))
+}
+
+// IsSecretDestination returns true if the provided object is a secret with
+// Destination label
+func IsSecretDestination(obj client.Object) bool {
+	return isObjectASecretWithProvidedLabel(obj, SecretLabelTypeKey, string(DestinationLabel))
+}
+
+func ValidateInternalSecret(internalSecret *corev1.Secret, expectedLabel SecretLabelType) error {
+	if internalSecret == nil {
+		return errors.New("provided secret is 'nil'")
+	}
+	if expectedLabel == "" {
+		return errors.New("an empty expected label provided. please provide 'IgnoreLabel' instead")
+	}
+	if expectedLabel != IgnoreLabel {
+		if expectedLabel != GetInternalLabel(internalSecret) {
+			return errors.New("expected and secret's labels don't match")
+		}
+	}
+	if internalSecret.Data == nil {
+		return errors.New("secret's data map is 'nil'")
+	}
+	// check whether all the keys are present in data
+	_, namespaceKeyOk := internalSecret.Data[NamespaceKey]
+	_, scNameKeyOk := internalSecret.Data[StorageClusterNameKey]
+	_, secretDataKeyOk := internalSecret.Data[SecretDataKey]
+	if !(namespaceKeyOk && scNameKeyOk && secretDataKeyOk) {
+		return errors.New("expected data map keys are not present")
+	}
+	return nil
+}
+
+// ValidateSourceSecret validates whether the given secret is a Source type
+func ValidateSourceSecret(sourceSecret *corev1.Secret) error {
+	return ValidateInternalSecret(sourceSecret, SourceLabel)
+}
+
+// ValidateDestinationSecret validates whether the given secret is a Destination type
+func ValidateDestinationSecret(sourceSecret *corev1.Secret) error {
+	return ValidateInternalSecret(sourceSecret, DestinationLabel)
+}
+
+// createInternalSecret a common function to create any type secret
+func createInternalSecret(secretNameAndNamespace types.NamespacedName,
+	storageClusterNameAndNamespace types.NamespacedName,
+	secretType SecretLabelType,
+	secretData []byte) *corev1.Secret {
+	retSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretNameAndNamespace.Name,
+			Namespace: secretNameAndNamespace.Namespace,
+			Labels: map[string]string{
+				SecretLabelTypeKey: string(secretType),
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			SecretDataKey:         secretData,
+			NamespaceKey:          []byte(storageClusterNameAndNamespace.Namespace),
+			StorageClusterNameKey: []byte(storageClusterNameAndNamespace.Name),
+		},
+	}
+	return retSecret
+}
+
+// CreateSourceSecret creates a source secret
+func CreateSourceSecret(secretNameAndNamespace types.NamespacedName,
+	storageClusterNameAndNamespace types.NamespacedName,
+	secretData []byte) *corev1.Secret {
+	return createInternalSecret(secretNameAndNamespace,
+		storageClusterNameAndNamespace,
+		SourceLabel,
+		secretData)
+}
+
+// CreateDestinationSecret creates a destination secret
+func CreateDestinationSecret(secretNameAndNamespace types.NamespacedName,
+	storageClusterNameAndNamespace types.NamespacedName,
+	secretData []byte) *corev1.Secret {
+	return createInternalSecret(secretNameAndNamespace,
+		storageClusterNameAndNamespace,
+		DestinationLabel,
+		secretData)
+}
+
+// CreateUniqueName function creates a sha512 hex sum from the given parameters
+func CreateUniqueName(params ...string) string {
+	genStr := strings.Join(params, "-")
+	return fmt.Sprintf("%x", sha512.Sum512([]byte(genStr)))
+}
+
+// CreatePeerRefFromSecret function creates a 'PeerRef' object
+// from the internal secret details
+func CreatePeerRefFromSecret(secret *corev1.Secret) (multiclusterv1alpha1.PeerRef, error) {
+	if err := ValidateInternalSecret(secret, IgnoreLabel); err != nil {
+		return multiclusterv1alpha1.PeerRef{}, err
+	}
+	retPeerRef := multiclusterv1alpha1.PeerRef{
+		ClusterName: secret.Namespace,
+		StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
+			Name:      string(secret.Data[StorageClusterNameKey]),
+			Namespace: string(secret.Data[NamespaceKey])},
+	}
+	return retPeerRef, nil
+}

--- a/controllers/manager.go
+++ b/controllers/manager.go
@@ -97,6 +97,14 @@ func (o *ManagerOptions) runManager() {
 	}
 	//+kubebuilder:scaffold:builder
 
+	if err = (&MirrorPeerSecretReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "MirrorPeer")
+		os.Exit(1)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)

--- a/controllers/mirrorpeersecret_controller.go
+++ b/controllers/mirrorpeersecret_controller.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2021 Red Hat OpenShift Data Foundation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/common"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// MirrorPeerSecretReconciler reconciles MirrorPeer CRs,
+// and source/destination Secrets
+type MirrorPeerSecretReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=multicluster.odf.openshift.io,resources=mirrorpeers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=multicluster.odf.openshift.io,resources=mirrorpeers/status,verbs=get
+//+kubebuilder:rbac:groups=core,resources=secrets;events,verbs=*
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
+
+// Reconcile standard reconcile function for MirrorPeerSecret controller
+func (r *MirrorPeerSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// reconcile for 'Secrets' (source or destination)
+	return ctrl.Result{}, mirrorPeerSecretReconcile(ctx, r.Client, req)
+}
+
+func mirrorPeerSecretReconcile(ctx context.Context, rc client.Client, req ctrl.Request) error {
+	var err error
+	logger := log.FromContext(ctx, "controller", "MirrorPeerSecret")
+	var peerSecret corev1.Secret
+	err = rc.Get(ctx, req.NamespacedName, &peerSecret)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("Secret not found", "req", req)
+			return processDeletedSecrets(ctx, rc, req.NamespacedName)
+		}
+		logger.Error(err, "Error in getting secret", "request", req)
+		return err
+	}
+	if common.IsSecretSource(&peerSecret) {
+		if err := common.ValidateSourceSecret(&peerSecret); err != nil {
+			logger.Error(err, "Provided source secret is not valid", "secret", peerSecret)
+			return err
+		}
+		err = createOrUpdateDestinationSecretsFromSource(ctx, rc, &peerSecret)
+		if err != nil {
+			logger.Error(err, "Updating the destination secret failed", "secret", peerSecret)
+			return err
+		}
+	} else if common.IsSecretDestination(&peerSecret) {
+		// a destination secret updation happened
+		err = processDestinationSecretUpdation(ctx, rc, &peerSecret)
+		if err != nil {
+			logger.Error(err, "Restoring destination secret failed", "secret", peerSecret)
+			return err
+		}
+	}
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *MirrorPeerSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}, builder.WithPredicates(common.SourceOrDestinationPredicate)).
+		Complete(r)
+}

--- a/controllers/named-peerref-with-data.go
+++ b/controllers/named-peerref-with-data.go
@@ -1,0 +1,133 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/common"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NamedPeerRefWithSecretData is an intermediate data structure,
+// when converting a source secret to corresponding peer destination secret
+type NamedPeerRefWithSecretData struct {
+	multiclusterv1alpha1.PeerRef
+	Name string
+	Data []byte
+}
+
+// NewNamedPeerRefWithSecretData creates a new PeerRef instance which has the source Name and Data details
+// attached to it.
+// Make sure we give a source secret and it's (one of the) connected PeerRef as arguments.
+func NewNamedPeerRefWithSecretData(secret *corev1.Secret, peerRef multiclusterv1alpha1.PeerRef) *NamedPeerRefWithSecretData {
+	var nPeerRef NamedPeerRefWithSecretData = NamedPeerRefWithSecretData{
+		Name:    secret.Name,
+		Data:    secret.Data[common.SecretDataKey],
+		PeerRef: peerRef,
+	}
+	return &nPeerRef
+}
+
+// GenerateSecret will generate a secret of provided type.
+// nPeerRef object contains TWO parts,
+//	 a. details of the secret, like name,namespace etc; that is to be generated
+// 	 b. data part that is to be passed on to the newly created secret
+// The type of secret (ie; source or destination) is passed as the argument
+func (nPR *NamedPeerRefWithSecretData) GenerateSecret(secretLabelType common.SecretLabelType) *corev1.Secret {
+	if nPR == nil {
+		return nil
+	}
+	secretNamespacedName := types.NamespacedName{
+		Name:      nPR.Name,
+		Namespace: nPR.ClusterName,
+	}
+	storageClusterNamespacedName := types.NamespacedName{
+		Name:      nPR.StorageClusterRef.Name,
+		Namespace: nPR.StorageClusterRef.Namespace,
+	}
+	var retSecret *corev1.Secret
+	if secretLabelType == common.DestinationLabel {
+		retSecret = common.CreateDestinationSecret(secretNamespacedName, storageClusterNamespacedName, nPR.Data)
+	} else if secretLabelType == common.SourceLabel {
+		retSecret = common.CreateSourceSecret(secretNamespacedName, storageClusterNamespacedName, nPR.Data)
+	}
+
+	return retSecret
+}
+
+func (nPR *NamedPeerRefWithSecretData) Request() (req reconcile.Request) {
+	if nPR == nil {
+		return
+	}
+	req.NamespacedName = types.NamespacedName{
+		Name:      nPR.Name,
+		Namespace: nPR.ClusterName,
+	}
+	return
+}
+
+func (nPR *NamedPeerRefWithSecretData) ErrorOnNilReceiver() (err error) {
+	if nPR == nil {
+		err = errors.New("'nil' receiver detected")
+	}
+	return err
+}
+
+// GetAssociatedSecret returns a secret in the cluster, which has the
+// same 'Name' and 'Namespace' matching the PeerRef's name and clustername
+func (nPR *NamedPeerRefWithSecretData) GetAssociatedSecret(ctx context.Context, rc client.Client, holdSecret *corev1.Secret) error {
+	if err := nPR.ErrorOnNilReceiver(); err != nil {
+		return err
+	}
+
+	var err error
+	localSecret := corev1.Secret{}
+	req := nPR.Request()
+	err = rc.Get(ctx, req.NamespacedName, &localSecret)
+	if err == nil && holdSecret != nil {
+		localSecret.DeepCopyInto(holdSecret)
+	}
+	return err
+}
+
+// CreateOrUpdateDestinationSecret creates/updates the destination secret from NamedPeerRefWithSecretData object
+func (nPR *NamedPeerRefWithSecretData) CreateOrUpdateDestinationSecret(ctx context.Context, rc client.Client) error {
+	err := nPR.ErrorOnNilReceiver()
+	if err != nil {
+		return err
+	}
+
+	logger := log.FromContext(ctx)
+	expectedDest := nPR.GenerateSecret(common.DestinationLabel)
+	var currentDest corev1.Secret
+	err = nPR.GetAssociatedSecret(ctx, rc, &currentDest)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("Creating destination secret", "secret", expectedDest)
+			return rc.Create(ctx, expectedDest)
+		}
+		logger.Error(err, "Unable to get the destination secret", "destination-ref", nPR.PeerRef)
+		return err
+	}
+
+	// recieved a destination secret, now compare
+	if !reflect.DeepEqual(expectedDest.Data, currentDest.Data) {
+		logger.Info("Updating the destination secret",
+			"current-data", currentDest.Data,
+			"expected-data", expectedDest.Data)
+		_, err := controllerutil.CreateOrUpdate(ctx, rc, &currentDest, func() error {
+			currentDest.Data = expectedDest.Data
+			return nil
+		})
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
MirrorPeerSecret watches BLUE secrets in the Hub's
Namespaces and syncs them to the corresponding GREEN
secrets in peered Namespaces.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>