### PR TITLE
MirrorPeer status conditions

### DIFF
--- a/api/v1alpha1/mirrorpeer_types.go
+++ b/api/v1alpha1/mirrorpeer_types.go
@@ -20,6 +20,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type PhaseType string
+
+const (
+	ExchangingSecret PhaseType = "ExchangingSecret"
+	ExchangedSecret  PhaseType = "ExchangedSecret"
+)
+
 // StorageClusterRef holds a reference to a StorageCluster
 type StorageClusterRef struct {
 	Name      string `json:"name"`
@@ -47,6 +54,8 @@ type MirrorPeerSpec struct {
 
 // MirrorPeerStatus defines the observed state of MirrorPeer
 type MirrorPeerStatus struct {
+	Phase   PhaseType `json:"phase,omitempty"`
+	Message string    `json:"message,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -66,6 +66,11 @@ spec:
             type: object
           status:
             description: MirrorPeerStatus defines the observed state of MirrorPeer
+            properties:
+              message:
+                type: string
+              phase:
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/config/crd/bases/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -68,6 +68,11 @@ spec:
             type: object
           status:
             description: MirrorPeerStatus defines the observed state of MirrorPeer
+            properties:
+              message:
+                type: string
+              phase:
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/common/predicate.go
+++ b/controllers/common/predicate.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ComposePredicates will compose a variable number of predicates and return a predicate that
+// will allow events that are allowed by any of the given predicates.
+func ComposePredicates(predicates ...predicate.Predicate) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Create(e) {
+					return true
+				}
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Delete(e) {
+					return true
+				}
+			}
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Update(e) {
+					return true
+				}
+			}
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Generic(e) {
+					return true
+				}
+			}
+			return false
+		},
+	}
+}


### PR DESCRIPTION
Depends on https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/17
This commit adds the status updates for MirrorPeer resources

```
status:
  message: Secret "d8433b8cb5b6d99c4d785ebd6082efd19cad50c" not found
  phase: ExchangingSecret
```
Sample status as tested