### PR TITLE
fix manager scheme & use it for testing reconciler

### DIFF
--- a/controllers/manager.go
+++ b/controllers/manager.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -25,6 +26,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(mgrScheme))
+	utilruntime.Must(clusterv1.AddToScheme(mgrScheme))
 
 	utilruntime.Must(multiclusterv1alpha1.AddToScheme(mgrScheme))
 	//+kubebuilder:scaffold:scheme

--- a/controllers/mirrorpeer_controller_test.go
+++ b/controllers/mirrorpeer_controller_test.go
@@ -24,7 +24,6 @@ import (
 
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,15 +31,10 @@ import (
 )
 
 func TestMirrorPeerReconcilerReconcile(t *testing.T) {
-	scheme := runtime.NewScheme()
-	err := clusterv1.AddToScheme(scheme)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = multiclusterv1alpha1.AddToScheme(scheme)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Using the same scheme as manager to ensure consistency.
+	// Using a different scheme for test might cause issues like
+	// missing scheme in manager
+	scheme := mgrScheme
 
 	mirrorpeer := multiclusterv1alpha1.MirrorPeer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -94,7 +88,7 @@ func TestMirrorPeerReconcilerReconcile(t *testing.T) {
 		},
 	}
 
-	_, err = r.Reconcile(ctx, req)
+	_, err := r.Reconcile(ctx, req)
 	if err != nil {
 		t.Errorf("MirrorPeerReconciler Reconcile() failed. Error: %s", err)
 	}


### PR DESCRIPTION
When using a different scheme for testing, we can not catch
issues like missing scheme from manager. So using the same
scheme as manager for reconciler testing.

Also, adding open-cluster-management scheme to manager scheme.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>