### PR TITLE
update integration test to include managedcluster crd and api

### DIFF
--- a/tests/testdata/clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/tests/testdata/clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -1,0 +1,244 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedclusters.cluster.open-cluster-management.io
+spec:
+  group: cluster.open-cluster-management.io
+  names:
+    kind: ManagedCluster
+    listKind: ManagedClusterList
+    plural: managedclusters
+    shortNames:
+    - mcl
+    - mcls
+    singular: managedcluster
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hubAcceptsClient
+      name: Hub Accepted
+      type: boolean
+    - jsonPath: .spec.managedClusterClientConfigs[*].url
+      name: Managed Cluster URLs
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ManagedClusterJoined")].status
+      name: Joined
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ManagedClusterConditionAvailable")].status
+      name: Available
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ManagedCluster represents the desired state and current status
+          of managed cluster. ManagedCluster is a cluster scoped resource. The name
+          is the cluster UID. \n The cluster join process follows a double opt-in
+          process: \n 1. Agent on managed cluster creates CSR on hub with cluster
+          UID and agent name. 2. Agent on managed cluster creates ManagedCluster on
+          hub. 3. Cluster admin on hub approves the CSR for UID and agent name of
+          the ManagedCluster. 4. Cluster admin sets spec.acceptClient of ManagedCluster
+          to true. 5. Cluster admin on managed cluster creates credential of kubeconfig
+          to hub. \n Once the hub creates the cluster namespace, the Klusterlet agent
+          on the ManagedCluster pushes the credential to the hub to use against the
+          kube-apiserver of the ManagedCluster."
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec represents a desired configuration for the agent on
+              the managed cluster.
+            type: object
+            properties:
+              hubAcceptsClient:
+                description: hubAcceptsClient represents that hub accepts the joining
+                  of Klusterlet agent on the managed cluster with the hub. The default
+                  value is false, and can only be set true when the user on hub has
+                  an RBAC rule to UPDATE on the virtual subresource of managedclusters/accept.
+                  When the value is set true, a namespace whose name is the same as
+                  the name of ManagedCluster is created on the hub. This namespace
+                  represents the managed cluster, also role/rolebinding is created
+                  on the namespace to grant the permision of access from the agent
+                  on the managed cluster. When the value is set to false, the namespace
+                  representing the managed cluster is deleted.
+                type: boolean
+              leaseDurationSeconds:
+                description: LeaseDurationSeconds is used to coordinate the lease
+                  update time of Klusterlet agents on the managed cluster. If its
+                  value is zero, the Klusterlet agent will update its lease every
+                  60 seconds by default
+                type: integer
+                format: int32
+              managedClusterClientConfigs:
+                description: ManagedClusterClientConfigs represents a list of the
+                  apiserver address of the managed cluster. If it is empty, the managed
+                  cluster has no accessible address for the hub to connect with it.
+                type: array
+                items:
+                  description: ClientConfig represents the apiserver address of the
+                    managed cluster. TODO include credential to connect to managed
+                    cluster kube-apiserver
+                  type: object
+                  properties:
+                    caBundle:
+                      description: CABundle is the ca bundle to connect to apiserver
+                        of the managed cluster. System certs are used if it is not
+                        set.
+                      type: string
+                      format: byte
+                    url:
+                      description: URL is the URL of apiserver endpoint of the managed
+                        cluster.
+                      type: string
+          status:
+            description: Status represents the current status of joined managed cluster
+            type: object
+            properties:
+              allocatable:
+                description: Allocatable represents the total allocatable resources
+                  on the managed cluster.
+                type: object
+                additionalProperties:
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+              capacity:
+                description: Capacity represents the total resource capacity from
+                  all nodeStatuses on the managed cluster.
+                type: object
+                additionalProperties:
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+              clusterClaims:
+                description: ClusterClaims represents cluster information that a managed
+                  cluster claims, for example a unique cluster identifier (id.k8s.io)
+                  and kubernetes version (kubeversion.open-cluster-management.io).
+                  They are written from the managed cluster. The set of claims is
+                  not uniform across a fleet, some claims can be vendor or version
+                  specific and may not be included from all managed clusters.
+                type: array
+                items:
+                  description: ManagedClusterClaim represents a ClusterClaim collected
+                    from a managed cluster.
+                  type: object
+                  properties:
+                    name:
+                      description: Name is the name of a ClusterClaim resource on
+                        managed cluster. It's a well known or customized name to identify
+                        the claim.
+                      type: string
+                      maxLength: 253
+                      minLength: 1
+                    value:
+                      description: Value is a claim-dependent string
+                      type: string
+                      maxLength: 1024
+                      minLength: 1
+              conditions:
+                description: Conditions contains the different condition statuses
+                  for this managed cluster.
+                type: array
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  type: object
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      type: string
+                      format: date-time
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      type: string
+                      maxLength: 32768
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      type: integer
+                      format: int64
+                      minimum: 0
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      type: string
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      type: string
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+              version:
+                description: Version represents the kubernetes version of the managed
+                  cluster.
+                type: object
+                properties:
+                  kubernetes:
+                    description: Kubernetes is the kubernetes version of managed cluster.
+                    type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
This commit adds ManagedCluster CRD and scheme to test suite.
Then it adds a test to verify that MirrorPeerReconciler can
access ManagedCluster objects during reconcile.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>