### PR TITLE
update operator InstallMode to AllNamespaces

### DIFF
--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -235,13 +235,13 @@ spec:
         serviceAccountName: odfmo-controller-manager
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - odf

--- a/config/manifests/bases/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/config/manifests/bases/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -27,13 +27,13 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - odf


### PR DESCRIPTION
This commit updates operator install mode to AllNamespaces
from SingleNamespace. It allows us to watch for resources
across all namespaces.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>