### PR TITLE
Add rule to agent's hub role for secret resource

### DIFF
--- a/addons/token-exchange/manifests/hub_role.yaml
+++ b/addons/token-exchange/manifests/hub_role.yaml
@@ -4,6 +4,9 @@ metadata:
   name: open-cluster-management:token-exchange:agent
   namespace: {{ .ClusterName }}
 rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 - apiGroups: ["addon.open-cluster-management.io"]
   resources: ["managedclusteraddons"]
   verbs: ["get", "list", "watch", "update", "patch"]


### PR DESCRIPTION
Issue: https://github.com/red-hat-storage/odf-multicluster-orchestrator/issues/35

Agent's logs were showing following error:
> E0901 18:20:13.644470       1 base_controller.go:264] "managedcluster-secret-tokenexchange-controller" controller failed to sync "openshift-storage/cluster-peer-token-ocs-storagecluster-cephcluster", err: failed to sync managed cluster secret "cluster-peer-token-ocs-storagecluster-cephcluster" from namespace openshift-storage to the hub cluster in namespace "local-cluster" err: failed to apply secret "d8433b8cb5b6d99c4d785ebd6082efd19cad50c" in namespace "local-cluster". Error secrets "d8433b8cb5b6d99c4d785ebd6082efd19cad50c" is forbidden: User "system:open-cluster-management:cluster:local-cluster:addon:tokenexchange:agent:tokenexchange" cannot get resource "secrets" in API group "" in the namespace "local-cluster"

Added a rule for `Secret` resource in token-exchange-agent's hub cluster `Role`.
