### PR TITLE
replace the setup-envtest shell script with the new binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ unit-test: ## Run unit tests
 
 ENVTEST_ASSETS_DIR=$(CWD)/testbin
 OPENSHIFT_CI ?= false
-test: ## Run integration tests.
+test: setup-envtest-bin ## Run integration tests.
 ifeq ($(OPENSHIFT_CI), true)
 	@echo "Running in OpenShift CI. Syncing vendor"
 	go mod tidy && go mod vendor
@@ -66,8 +66,7 @@ else
 endif
 	make manifests generate fmt vet
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./tests/integration/... -v -tags integration -coverprofile integration-cover.out
+	source <($(SETUP_ENVTEST_BIN) use -i -p env 1.21.x); go test ./tests/integration/... -v -tags integration -coverprofile integration-cover.out
 
 ##@ Build
 

--- a/hack/make/tools.mk
+++ b/hack/make/tools.mk
@@ -73,3 +73,8 @@ endif
 KUBELINTER_BIN := $(CWD)/bin/kube-linter
 kubelinter-bin: ## Download kube-linter locally if necessary
 	$(call go-get-tool,$(KUBELINTER_BIN),golang.stackrox.io/kube-linter/cmd/kube-linter@0.2.2)
+
+.PHONY: setup-envtest-bin
+SETUP_ENVTEST_BIN := $(CWD)/bin/setup-envtest
+setup-envtest-bin: ## Download setup-envtest locally if necessary
+	$(call go-get-tool,$(SETUP_ENVTEST_BIN),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)


### PR DESCRIPTION
This PR replaces the setup-envtest.sh script with the go binary that controller-runtime pkg has introduced to make setting up of the test env simpler. (https://github.com/kubernetes-sigs/controller-runtime/pull/1488)

