### PR TITLE
Bug 2005843: Label ODF multicluster operator pod based on deployment name

### DIFF
--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -155,12 +155,12 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              control-plane: odfmo-controller-manager
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: controller-manager
+                control-plane: odfmo-controller-manager
             spec:
               containers:
               - args:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: odfmo-controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,16 +11,16 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: odfmo-controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: odfmo-controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: odfmo-controller-manager
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Keep labels of one operator pods always unique from the other
operator pods, So that label based fetching of pods can be more
deterministic.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2005843

Signed-off-by: Gowtham Shanmugasundaram <gshanmug@redhat.com>