### PR TITLE
Bug 2005843: Label ODF multicluster operator pod based on deployment name

### DIFF
--- a/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
+  labels:
+    control-plane: odfmo-controller-manager
   name: mirrorpeers.multicluster.odf.openshift.io
 spec:
   group: multicluster.odf.openshift.io

--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -8,6 +8,9 @@ metadata:
           "apiVersion": "multicluster.odf.openshift.io/v1alpha1",
           "kind": "MirrorPeer",
           "metadata": {
+            "labels": {
+              "control-plane": "odfmo-controller-manager"
+            },
             "name": "mirrorpeer-sample"
           },
           "spec": {
@@ -18,6 +21,8 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+  labels:
+    control-plane: odfmo-controller-manager
   name: odf-multicluster-orchestrator.v0.0.1
   namespace: placeholder
 spec:
@@ -155,12 +160,12 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              control-plane: odfmo-controller-manager
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: controller-manager
+                control-plane: odfmo-controller-manager
             spec:
               containers:
               - args:

--- a/bundle/manifests/odfmo-controller-manager_v1_serviceaccount.yaml
+++ b/bundle/manifests/odfmo-controller-manager_v1_serviceaccount.yaml
@@ -2,4 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
+  labels:
+    control-plane: odfmo-controller-manager
   name: odfmo-controller-manager

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -25,3 +25,6 @@ resources:
 #    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
 #    - op: remove
 #      path: /spec/template/spec/volumes/0
+# Labels to add to all resources and selectors.
+commonLabels:
+ control-plane: odfmo-controller-manager


### PR DESCRIPTION
Keep labels of one operator pods always unique from the other
operator pods, So that label based fetching of pods can be more
deterministic.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2005843