### PR TITLE
Bug 2006176: token-exchange-agent pod logs flooded with failed to sync and Failed to watch messages

### DIFF
--- a/addons/token-exchange/manifests/hub_role.yaml
+++ b/addons/token-exchange/manifests/hub_role.yaml
@@ -4,6 +4,9 @@ metadata:
   name: open-cluster-management:token-exchange:agent
   namespace: {{ .ClusterName }}
 rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 - apiGroups: ["addon.open-cluster-management.io"]
   resources: ["managedclusteraddons"]
   verbs: ["get", "list", "watch", "update", "patch"]


### PR DESCRIPTION
- Agent was not creating BLUE secret for one of the managed cluster.
- Agent logs showed "forbidden User" error.

 Added a rule for `Secrets` in hub's `Role`.