### PR TITLE
Increase timeout for exchanging secrets test

### DIFF
--- a/tests/integration/mirrorpeer_status_test.go
+++ b/tests/integration/mirrorpeer_status_test.go
@@ -237,7 +237,7 @@ var _ = Describe("MirrorPeer Status Tests", func() {
 				}, &mp)
 				Expect(err).NotTo(HaveOccurred())
 				return mp.Status.Phase
-			}, 20*time.Second, 2*time.Second).Should(Equal(multiclusterv1alpha1.ExchangedSecret))
+			}, 5*time.Minute, 2*time.Second).Should(Equal(multiclusterv1alpha1.ExchangedSecret))
 
 		})
 	})


### PR DESCRIPTION
Increased timeout for exchanging secrets test as it was causing the CI
to fail occasionally.