### PR TITLE
Fix ramenConfig parse issue using post creating MirrorPeer creation

### DIFF
--- a/controllers/common-controller-utils.go
+++ b/controllers/common-controller-utils.go
@@ -10,7 +10,6 @@ import (
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/common"
-	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	yaml "sigs.k8s.io/yaml"
 )
 
 // createOrUpdateDestinationSecretsFromSource updates all destination secrets

--- a/controllers/common-controller-utils_test.go
+++ b/controllers/common-controller-utils_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
@@ -29,26 +30,29 @@ import (
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/common"
 	"github.com/stretchr/testify/assert"
-	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	yaml "sigs.k8s.io/yaml"
 )
 
 var (
-	SecretName                        = "s3Secret"
-	S3ProfileName                     = "s3Profile"
-	TestS3BucketName                  = "s3bucket"
-	TestAwsAccessKeyId                = "awskeyid"
-	TestAwssecretaccesskey            = "awsaccesskey"
-	TestS3RouteHost                   = "https://s3.endpoint"
-	TestSourceManagedClusterName      = "east"
-	TestDestinationManagedClusterName = "west"
-	StorageClusterName                = "ocs-storagecluster"
-	StorageClusterNamespace           = "openshift-storage"
+	SecretName                         = "s3Secret"
+	S3ProfileName                      = "s3Profile"
+	TestS3BucketName                   = "s3bucket"
+	TestAwsAccessKeyId                 = "awskeyid"
+	TestAwssecretaccesskey             = "awsaccesskey"
+	TestS3RouteHost                    = "https://s3.endpoint"
+	TestSourceManagedClusterEast       = "east"
+	TestDestinationManagedClusterWest  = "west"
+	TestSourceManagedClusterSoth       = "south"
+	TestDestinationManagedClusterNorth = "north"
+
+	StorageClusterName      = "ocs-storagecluster"
+	StorageClusterNamespace = "openshift-storage"
 )
 
 func fakeMirrorPeers(manageS3 bool) []multiclusterv1alpha1.MirrorPeer {
@@ -61,14 +65,14 @@ func fakeMirrorPeers(manageS3 bool) []multiclusterv1alpha1.MirrorPeer {
 				ManageS3: manageS3,
 				Items: []multiclusterv1alpha1.PeerRef{
 					{
-						ClusterName: TestSourceManagedClusterName,
+						ClusterName: TestSourceManagedClusterEast,
 						StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
 							Name:      StorageClusterName,
 							Namespace: StorageClusterNamespace,
 						},
 					},
 					{
-						ClusterName: TestDestinationManagedClusterName,
+						ClusterName: TestDestinationManagedClusterWest,
 						StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
 							Name:      StorageClusterName,
 							Namespace: StorageClusterNamespace,
@@ -115,7 +119,15 @@ func fakeS3InternalSecret(t *testing.T, clusterName string) *corev1.Secret {
 }
 
 func getFakeClient(t *testing.T, mgrScheme *runtime.Scheme) client.Client {
-	config, err := yaml.Marshal(rmn.RamenConfig{})
+	emptyConfig, err := yaml.Marshal(rmn.RamenConfig{})
+	assert.NoError(t, err)
+	filledConfig1, err := yaml.Marshal(rmn.RamenConfig{
+		S3StoreProfiles: getS3Profile("namespace1", TestSourceManagedClusterSoth, TestDestinationManagedClusterNorth),
+	})
+	assert.NoError(t, err)
+	filledConfig2, err := yaml.Marshal(rmn.RamenConfig{
+		S3StoreProfiles: getS3Profile("namespace2", TestSourceManagedClusterEast, TestDestinationManagedClusterWest),
+	})
 	assert.NoError(t, err)
 
 	obj := []runtime.Object{
@@ -125,18 +137,36 @@ func getFakeClient(t *testing.T, mgrScheme *runtime.Scheme) client.Client {
 				Namespace: common.RamenHubNamespace,
 			},
 			Data: map[string]string{
-				"ramen_manager_config.yaml": string(config),
+				"ramen_manager_config.yaml": string(emptyConfig),
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.RamenHubOperatorConfigName,
+				Namespace: "namespace1",
+			},
+			Data: map[string]string{
+				"ramen_manager_config.yaml": string(filledConfig1),
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.RamenHubOperatorConfigName,
+				Namespace: "namespace2",
+			},
+			Data: map[string]string{
+				"ramen_manager_config.yaml": string(filledConfig2),
 			},
 		},
 	}
 	return fake.NewClientBuilder().WithScheme(mgrScheme).WithRuntimeObjects(obj...).Build()
 }
 
-func getRamenConfig(t *testing.T, ctx context.Context, fakeClient client.Client) rmn.RamenConfig {
+func getRamenConfig(t *testing.T, ctx context.Context, fakeClient client.Client, ramenNamespace string) rmn.RamenConfig {
 	currentRamenConfigMap := corev1.ConfigMap{}
 	namespacedName := types.NamespacedName{
 		Name:      common.RamenHubOperatorConfigName,
-		Namespace: common.RamenHubNamespace,
+		Namespace: ramenNamespace,
 	}
 	err := fakeClient.Get(ctx, namespacedName, &currentRamenConfigMap)
 	assert.NoError(t, err)
@@ -148,11 +178,11 @@ func getRamenConfig(t *testing.T, ctx context.Context, fakeClient client.Client)
 	return ramenConfig
 }
 
-func getRamenS3Secret(secretName string, ctx context.Context, fakeClient client.Client) (corev1.Secret, error) {
+func getRamenS3Secret(secretName string, ctx context.Context, fakeClient client.Client, ramenNamespace string) (corev1.Secret, error) {
 	ramenSecret := corev1.Secret{}
 	namespacedName := types.NamespacedName{
 		Name:      common.CreateUniqueSecretName(secretName, StorageClusterNamespace, StorageClusterName, common.S3ProfilePrefix),
-		Namespace: common.RamenHubNamespace,
+		Namespace: ramenNamespace,
 	}
 	err := fakeClient.Get(ctx, namespacedName, &ramenSecret)
 
@@ -160,30 +190,34 @@ func getRamenS3Secret(secretName string, ctx context.Context, fakeClient client.
 
 }
 
-func expectedRamenConfig() rmn.RamenConfig {
-	return rmn.RamenConfig{
-		S3StoreProfiles: []rmn.S3StoreProfile{
-			{
-				S3ProfileName:        fmt.Sprintf("%s-%s-%s", common.S3ProfilePrefix, TestSourceManagedClusterName, StorageClusterName),
-				S3Bucket:             TestS3BucketName,
-				S3CompatibleEndpoint: TestS3RouteHost,
-				S3Region:             "",
-				S3SecretRef: corev1.SecretReference{
-					Name:      common.CreateUniqueSecretName(TestSourceManagedClusterName, StorageClusterNamespace, StorageClusterName, common.S3ProfilePrefix),
-					Namespace: common.RamenHubNamespace,
-				},
-			},
-			{
-				S3ProfileName:        fmt.Sprintf("%s-%s-%s", common.S3ProfilePrefix, TestDestinationManagedClusterName, StorageClusterName),
-				S3Bucket:             TestS3BucketName,
-				S3CompatibleEndpoint: TestS3RouteHost,
-				S3Region:             "",
-				S3SecretRef: corev1.SecretReference{
-					Name:      common.CreateUniqueSecretName(TestDestinationManagedClusterName, StorageClusterNamespace, StorageClusterName, common.S3ProfilePrefix),
-					Namespace: common.RamenHubNamespace,
-				},
+func getS3Profile(ramenNamespace string, sourceManagedClusterName string, destinationManagedClusterName string) []rmn.S3StoreProfile {
+	return []rmn.S3StoreProfile{
+		{
+			S3ProfileName:        fmt.Sprintf("%s-%s-%s", common.S3ProfilePrefix, sourceManagedClusterName, StorageClusterName),
+			S3Bucket:             TestS3BucketName,
+			S3CompatibleEndpoint: TestS3RouteHost,
+			S3Region:             "",
+			S3SecretRef: corev1.SecretReference{
+				Name:      common.CreateUniqueSecretName(sourceManagedClusterName, StorageClusterNamespace, StorageClusterName, common.S3ProfilePrefix),
+				Namespace: ramenNamespace,
 			},
 		},
+		{
+			S3ProfileName:        fmt.Sprintf("%s-%s-%s", common.S3ProfilePrefix, destinationManagedClusterName, StorageClusterName),
+			S3Bucket:             TestS3BucketName,
+			S3CompatibleEndpoint: TestS3RouteHost,
+			S3Region:             "",
+			S3SecretRef: corev1.SecretReference{
+				Name:      common.CreateUniqueSecretName(destinationManagedClusterName, StorageClusterNamespace, StorageClusterName, common.S3ProfilePrefix),
+				Namespace: ramenNamespace,
+			},
+		},
+	}
+}
+
+func expectedRamenConfig(ramenNamespace string, source, destination string) rmn.RamenConfig {
+	return rmn.RamenConfig{
+		S3StoreProfiles: getS3Profile(ramenNamespace, source, destination),
 	}
 }
 
@@ -197,44 +231,64 @@ func expectedRamenSecretData() map[string][]byte {
 func TestMirrorPeerSecretReconcile(t *testing.T) {
 	cases := []struct {
 		name            string
+		ramenNamespace  string
 		manageS3        bool
 		ignoreS3Profile bool
 	}{
 		{
 			name:            "Managing S3 Profile disabled",
+			ramenNamespace:  common.RamenHubNamespace,
 			manageS3:        false,
 			ignoreS3Profile: true,
 		},
 		{
-			name:            "Managing S3 Profile",
+			name:            "Creating new S3 Profile in empty Ramen Config",
+			ramenNamespace:  common.RamenHubNamespace,
+			manageS3:        true,
+			ignoreS3Profile: false,
+		},
+		{
+			name:            "Creating new S3 Profile in filled Ramen Config",
+			ramenNamespace:  "namespace1",
+			manageS3:        true,
+			ignoreS3Profile: false,
+		},
+		{
+			name:            "Updating existing S3 Profile in filled Ramen Config",
+			ramenNamespace:  "namespace2",
 			manageS3:        true,
 			ignoreS3Profile: false,
 		},
 	}
 
+	fakeClient := getFakeClient(t, mgrScheme)
 	for _, c := range cases {
-		fakeClient := getFakeClient(t, mgrScheme)
+		os.Setenv("ODR_NAMESPACE", c.ramenNamespace)
 		ctx := context.TODO()
-		err := createOrUpdateSecretsFromInternalSecret(ctx, fakeClient, fakeS3InternalSecret(t, TestSourceManagedClusterName), fakeMirrorPeers(c.manageS3))
+		err := createOrUpdateSecretsFromInternalSecret(ctx, fakeClient, fakeS3InternalSecret(t, TestSourceManagedClusterEast), fakeMirrorPeers(c.manageS3))
 		assert.NoError(t, err)
-		err = createOrUpdateSecretsFromInternalSecret(ctx, fakeClient, fakeS3InternalSecret(t, TestDestinationManagedClusterName), fakeMirrorPeers(c.manageS3))
+		err = createOrUpdateSecretsFromInternalSecret(ctx, fakeClient, fakeS3InternalSecret(t, TestDestinationManagedClusterWest), fakeMirrorPeers(c.manageS3))
 		assert.NoError(t, err)
 
 		if c.ignoreS3Profile {
 			// assert ramen config map update
-			ramenConfig := getRamenConfig(t, ctx, fakeClient)
-			assert.True(t, reflect.DeepEqual(rmn.RamenConfig{S3StoreProfiles: []rmn.S3StoreProfile{}}, ramenConfig))
+			ramenConfig := getRamenConfig(t, ctx, fakeClient, c.ramenNamespace)
+			assert.True(t, reflect.DeepEqual(rmn.RamenConfig{S3StoreProfiles: []rmn.S3StoreProfile(nil)}, ramenConfig))
 		} else {
 			// assert ramen config map update
-			ramenConfig := getRamenConfig(t, ctx, fakeClient)
-			assert.True(t, reflect.DeepEqual(expectedRamenConfig(), ramenConfig))
+			ramenConfig := getRamenConfig(t, ctx, fakeClient, c.ramenNamespace)
+			expectedConfig := expectedRamenConfig(c.ramenNamespace, TestSourceManagedClusterEast, TestDestinationManagedClusterWest)
+			if c.name == "Creating new S3 Profile in filled Ramen Config" {
+				expectedConfig.S3StoreProfiles = append(expectedRamenConfig(c.ramenNamespace, TestSourceManagedClusterSoth, TestDestinationManagedClusterNorth).S3StoreProfiles, expectedConfig.S3StoreProfiles...)
+			}
+			assert.True(t, reflect.DeepEqual(expectedConfig, ramenConfig))
 
 			// asset ramen s3 secret creation
-			ramenSecret, err := getRamenS3Secret(TestSourceManagedClusterName, ctx, fakeClient)
+			ramenSecret, err := getRamenS3Secret(TestSourceManagedClusterEast, ctx, fakeClient, c.ramenNamespace)
 			assert.NoError(t, err)
 			assert.True(t, reflect.DeepEqual(expectedRamenSecretData(), ramenSecret.Data))
 
-			ramenSecret, err = getRamenS3Secret(TestDestinationManagedClusterName, ctx, fakeClient)
+			ramenSecret, err = getRamenS3Secret(TestDestinationManagedClusterWest, ctx, fakeClient, c.ramenNamespace)
 			assert.NoError(t, err)
 			assert.True(t, reflect.DeepEqual(expectedRamenSecretData(), ramenSecret.Data))
 		}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.22.1
 	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v12.0.0+incompatible
@@ -23,6 +22,7 @@ require (
 	open-cluster-management.io/addon-framework v0.0.0-20210709073210-719dbb79d275
 	open-cluster-management.io/api v0.0.0-20210727123024-41c7397e9f2d
 	sigs.k8s.io/controller-runtime v0.9.6
+	sigs.k8s.io/yaml v1.3.0
 
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3210,8 +3210,9 @@ sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
-sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2zzQcaEFbx8wA8rck=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=


### PR DESCRIPTION
Default YAML:
```
kind: RamenConfig
health:
  healthProbeBindAddress: :8081
metrics:
  bindAddress: 127.0.0.1:9289
webhook:
  port: 9443
leaderElection:
  leaderElect: true
  resourceName: hub.ramendr.openshift.io
ramenControllerType: "dr-hub"
```

After updated by MCO:
```
MaxConcurrentReconciles: 0
apiVersion: ramendr.openshift.io/v1alpha1
health:
  healthProbeBindAddress: :8081
kind: RamenConfig
leaderElection:
  leaderElect: true
  leaseDuration: 0s
  renewDeadline: 0s
  resourceLock: ""
  resourceName: hub.ramendr.openshift.io
  resourceNamespace: ""
  retryPeriod: 0s
metrics:
  bindAddress: 127.0.0.1:9289
ramenControllerType: dr-hub
s3StoreProfiles:
- s3Bucket: odrbucket-9af550a2d48c
  s3CompatibleEndpoint: https://s3-openshift-storage.apps.bot-41ec5b55-5728-48b6-8874-936be1c7de01.devcluster.openshift.com
  s3ProfileName: s3profile-local-cluster-ocs-storagecluster
  s3Region: ""
  s3SecretRef:
    name: 10d0befe9022a438cb7216391c32e6eba32f19f
    namespace: openshift-dr-system
- s3Bucket: odrbucket-9af550a2d48c
  s3CompatibleEndpoint: https://s3-openshift-storage.apps.odf-dade9868-20fb-471e-bcd0-3fefc21db2bf.devcluster.openshift.com
  s3ProfileName: s3profile-remote-cluster-ocs-storagecluster
  s3Region: ""
  s3SecretRef:
    name: 2152428ad05a47e326a4b6ae6adfcaa21f2896c
    namespace: openshift-dr-system
webhook:
  port: 9443
```


Signed-off-by: Gowtham Shanmugasundaram <gshanmug@redhat.com>