### PR TITLE
update ramen dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/library-go v0.0.0-20210727084322-8a96c0a97c06
 	github.com/openshift/ocs-operator v0.0.1-alpha2
-	github.com/ramendr/ramen v0.0.0-20220114120954-238a9a87a098
+	github.com/ramendr/ramen v0.0.0-20220201125512-ff29bf0d3dbb
 	github.com/rook/rook v1.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1966,8 +1966,8 @@ github.com/quasilyte/go-ruleguard v0.2.0/go.mod h1:2RT/tf0Ce0UDj5y243iWKosQogJd8
 github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:rlzQ04UMyJXu/aOvhd8qT+hvDrFpiwqp8MRXDY9szc0=
 github.com/quasilyte/regex/syntax v0.0.0-20200805063351-8f842688393c/go.mod h1:rlzQ04UMyJXu/aOvhd8qT+hvDrFpiwqp8MRXDY9szc0=
 github.com/quobyte/api v0.1.2/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
-github.com/ramendr/ramen v0.0.0-20220114120954-238a9a87a098 h1:EBLxgp7QqzM8X3n60FXpWaC2F9BxkKYPpeIFa0QzROI=
-github.com/ramendr/ramen v0.0.0-20220114120954-238a9a87a098/go.mod h1:MlNNTieEMzemaNg0Ye3TRnISmINl5ofYnRLuQ81urPA=
+github.com/ramendr/ramen v0.0.0-20220201125512-ff29bf0d3dbb h1:KtrwYmJEddUZzT9EmKAiPbflncTtPIC75z27sWCbqEw=
+github.com/ramendr/ramen v0.0.0-20220201125512-ff29bf0d3dbb/go.mod h1:ZSiV2uBaZJCLjEewmvHrXlbq5C6AzqVictDiFQ0436g=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rickb777/date v1.12.5-0.20200422084442-6300e543c4d9/go.mod h1:L8WrssTzvgYw34/Ppa0JpJfI7KKXZ2cVGI6Djt0brUU=
 github.com/rickb777/plural v1.2.0/go.mod h1:UdpyWFCGbo3mvK3f/PfZOAOrkjzJlYN/sD46XNWJ+Es=


### PR DESCRIPTION
Before:
```
apiVersion: ramendr.openshift.io/v1alpha1
kind: RamenConfig
health:
  healthProbeBindAddress: :8081
metrics:
  bindAddress: 127.0.0.1:9289
webhook:
  port: 9443
leaderElection:
  leaderElect: true
  resourceName: hub.ramendr.openshift.io
ramenControllerType: "dr-hub"
drClusterOperator:
  deploymentAutomationEnabled: false
  channelName: stable-4.10
  packageName: odr-cluster-operator
  namespaceName: openshift-dr-system
  catalogSourceName: redhat-operators
  catalogSourceNamespaceName: openshift-marketplace
  clusterServiceVersionName: odr-cluster-operator.v0.0.1
```


After ODFMO update
```
apiVersion: ramendr.openshift.io/v1alpha1
drClusterOperator:
  catalogSourceName: redhat-operators
  catalogSourceNamespaceName: openshift-marketplace
  channelName: stable-4.10
  clusterServiceVersionName: odr-cluster-operator.v0.0.1
  namespaceName: openshift-dr-system
  packageName: odr-cluster-operator
health:
  healthProbeBindAddress: :8081
kind: RamenConfig
leaderElection:
  leaderElect: true
  leaseDuration: 0s
  renewDeadline: 0s
  resourceLock: ""
  resourceName: hub.ramendr.openshift.io
  resourceNamespace: ""
  retryPeriod: 0s
metrics:
  bindAddress: 127.0.0.1:9289
ramenControllerType: dr-hub
s3StoreProfiles:
- s3Bucket: odrbucket-bcf3041f21d7
  s3CompatibleEndpoint: https://s3-openshift-storage.apps.bot-ce85487b-896d-4e2c-9344-486d4285cba5.devcluster.openshift.com
  s3ProfileName: s3profile-local-cluster-ocs-storagecluster
  s3Region: noobaa
  s3SecretRef:
    name: 10d0befe9022a438cb7216391c32e6eba32f19f
    namespace: openshift-dr-system
- s3Bucket: odrbucket-bcf3041f21d7
  s3CompatibleEndpoint: https://s3-openshift-storage.apps.bot-1a9bc5cd-af2d-46b5-98f7-14a19053e787.devcluster.openshift.com
  s3ProfileName: s3profile-spoke-cluster-ocs-storagecluster
  s3Region: noobaa
  s3SecretRef:
    name: 756bd87b55371f0a9a791269d78efdaeb2617fc
    namespace: openshift-dr-system
webhook:
  port: 9443
```

`deploymentAutomationEnabled: false` is disappearing because the default is false and `json:"deploymentAutomationEnabled,omitempty"` is removed when the value is false while parsing. I checked with true value and it never disappears when its value is true.

Signed-off-by: Gowtham Shanmugasundaram <gshanmug@redhat.com>