### PR TITLE
Add hub recovery labels to mirrorpeer

### DIFF
--- a/controllers/mirrorpeer_controller_test.go
+++ b/controllers/mirrorpeer_controller_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 /*
@@ -91,5 +92,15 @@ func TestMirrorPeerReconcilerReconcile(t *testing.T) {
 	_, err := r.Reconcile(ctx, req)
 	if err != nil {
 		t.Errorf("MirrorPeerReconciler Reconcile() failed. Error: %s", err)
+	}
+
+	var mp multiclusterv1alpha1.MirrorPeer
+	err = r.Get(ctx, req.NamespacedName, &mp)
+	if err != nil {
+		t.Errorf("Failed to get MirrorPeer. Error: %s", err)
+	}
+
+	if val, ok := mp.Labels[hubRecoveryLabel]; !ok || val != "resource" {
+		t.Errorf("MirrorPeer.Labels[%s] is not set correctly. Expected: %s, Actual: %s", hubRecoveryLabel, "resource", val)
 	}
 }


### PR DESCRIPTION
This commit adds recovery labels for ACM backup and restore.

https://issues.redhat.com/browse/ACM-1001

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>