### PR TITLE
Support for Metro DR (Sync Mode) 

### DIFF
--- a/addons/token-exchange/agent_mirrorpeer_controller_test.go
+++ b/addons/token-exchange/agent_mirrorpeer_controller_test.go
@@ -43,6 +43,7 @@ var (
 			Name: "mirrorpeer-with-proper-scheduling-intervals",
 		},
 		Spec: multiclusterv1alpha1.MirrorPeerSpec{
+			Type:                "async",
 			Items:               mpItems,
 			SchedulingIntervals: []string{"10m", "5m", "30m", "1h", "5m"},
 		},
@@ -52,6 +53,7 @@ var (
 			Name: "mirrorpeer-with-invalid-scheduling-intervals",
 		},
 		Spec: multiclusterv1alpha1.MirrorPeerSpec{
+			Type:                "async",
 			Items:               mpItems,
 			SchedulingIntervals: []string{"1p", "2o", "3h", "4hh", "5md"},
 		},

--- a/addons/token-exchange/manifests/spoke_deployment.yaml
+++ b/addons/token-exchange/manifests/spoke_deployment.yaml
@@ -31,6 +31,7 @@ spec:
           - "--hub-kubeconfig=/var/run/hub/kubeconfig"
           - "--cluster-name={{ .ClusterName }}"
           - "--namespace={{ .AddonInstallNamespace }}"
+          - "--mode={{ .DRMode }}"
         volumeMounts:
           - name: hub-config
             mountPath: /var/run/hub

--- a/addons/token-exchange/rook_secret_handler.go
+++ b/addons/token-exchange/rook_secret_handler.go
@@ -24,7 +24,6 @@ type rookSecretHandler struct {
 }
 
 const (
-	RookSecretHandlerName            = "rook"
 	RookType                         = "kubernetes.io/rook"
 	RookDefaultBlueSecretMatchString = "cluster-peer-token"
 )

--- a/addons/token-exchange/s3_secret_handler.go
+++ b/addons/token-exchange/s3_secret_handler.go
@@ -22,7 +22,6 @@ type s3SecretHandler struct {
 }
 
 const (
-	S3SecretHandlerName       = "s3"
 	ObjectBucketClaimKind     = "ObjectBucketClaim"
 	S3BucketName              = "BUCKET_NAME"
 	S3BucketRegion            = "BUCKET_REGION"

--- a/addons/token-exchange/token_exchanger_addon.go
+++ b/addons/token-exchange/token_exchanger_addon.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"encoding/pem"
 	"fmt"
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/utils"
 
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -76,11 +77,13 @@ func (a *TokenExchangeAddon) Manifests(cluster *clusterv1.ManagedCluster, addon 
 		ClusterName           string
 		AddonInstallNamespace string
 		Image                 string
+		DRMode                string
 	}{
 		KubeConfigSecret:      fmt.Sprintf("%s-hub-kubeconfig", TokenExchangeName),
 		AddonInstallNamespace: installNamespace,
 		ClusterName:           cluster.Name,
 		Image:                 a.AgentImage,
+		DRMode:                addon.Annotations[utils.DRModeAnnotationKey],
 	}
 
 	for _, file := range agentDeploymentFiles {

--- a/addons/token-exchange/token_exchanger_agent.go
+++ b/addons/token-exchange/token_exchanger_agent.go
@@ -2,6 +2,7 @@ package addons
 
 import (
 	"context"
+	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -34,6 +35,7 @@ func NewAgentCommand() *cobra.Command {
 type AgentOptions struct {
 	HubKubeconfigFile string
 	SpokeClusterName  string
+	DRMode            string
 }
 
 // NewAgentOptions returns the flags with default value set
@@ -45,6 +47,7 @@ func (o *AgentOptions) AddFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.StringVar(&o.HubKubeconfigFile, "hub-kubeconfig", o.HubKubeconfigFile, "Location of kubeconfig file to connect to hub cluster.")
 	flags.StringVar(&o.SpokeClusterName, "cluster-name", o.SpokeClusterName, "Name of spoke cluster.")
+	flags.StringVar(&o.DRMode, "mode", o.DRMode, "The DR mode of token exchange addon. Valid values are: 'sync', 'async'")
 }
 
 // RunAgent starts the controllers on agent to process work from hub.
@@ -66,7 +69,7 @@ func (o *AgentOptions) RunAgent(ctx context.Context, controllerContext *controll
 		return err
 	}
 	hubKubeInformerFactory := informers.NewSharedInformerFactoryWithOptions(hubKubeClient, 10*time.Minute, informers.WithNamespace(o.SpokeClusterName))
-	err = registerHandler(controllerContext.KubeConfig, hubRestConfig)
+	err = registerHandler(multiclusterv1alpha1.DRType(o.DRMode), controllerContext.KubeConfig, hubRestConfig)
 	if err != nil {
 		return err
 	}

--- a/api/v1alpha1/mirrorpeer_types.go
+++ b/api/v1alpha1/mirrorpeer_types.go
@@ -21,11 +21,13 @@ import (
 )
 
 type PhaseType string
-type MirroringMode string
+type DRType string
 
 const (
 	ExchangingSecret PhaseType = "ExchangingSecret"
 	ExchangedSecret  PhaseType = "ExchangedSecret"
+	Sync             DRType    = "sync"
+	Async            DRType    = "async"
 )
 
 // StorageClusterRef holds a reference to a StorageCluster
@@ -46,6 +48,11 @@ type PeerRef struct {
 
 // MirrorPeerSpec defines the desired state of MirrorPeer
 type MirrorPeerSpec struct {
+	// Type represents the mode of DR operation (sync or async)
+	// +kubebuilder:default=async
+	// +kubebuilder:validation:Enum=async;sync
+	Type DRType `json:"type"`
+
 	// Items is a list of PeerRef.
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:MinItems=2

--- a/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -73,8 +73,16 @@ spec:
                 items:
                   type: string
                 type: array
+              type:
+                default: async
+                description: Type represents the mode of DR operation (sync or async)
+                enum:
+                - async
+                - sync
+                type: string
             required:
             - items
+            - type
             type: object
           status:
             description: MirrorPeerStatus defines the observed state of MirrorPeer

--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
       ]
     capabilities: Basic Install
     olm.skipRange: ""
-    operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   labels:
     control-plane: odfmo-controller-manager

--- a/config/crd/bases/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/config/crd/bases/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -73,8 +73,16 @@ spec:
                 items:
                   type: string
                 type: array
+              type:
+                default: async
+                description: Type represents the mode of DR operation (sync or async)
+                enum:
+                - async
+                - sync
+                type: string
             required:
             - items
+            - type
             type: object
           status:
             description: MirrorPeerStatus defines the observed state of MirrorPeer

--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -140,13 +140,15 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{Requeue: true}, nil
 		}
 	}
-
 	// Create or Update ManagedClusterAddon
 	for i := range mirrorPeer.Spec.Items {
 		managedClusterAddOn := addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tokenexchange.TokenExchangeName,
 				Namespace: mirrorPeer.Spec.Items[i].ClusterName,
+				Annotations: map[string]string{
+					utils.DRModeAnnotationKey: string(mirrorPeer.Spec.Type),
+				},
 			},
 		}
 		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &managedClusterAddOn, func() error {

--- a/controllers/utils/s3.go
+++ b/controllers/utils/s3.go
@@ -22,6 +22,11 @@ const (
 
 	// ramen
 	RamenHubOperatorConfigName = "ramen-hub-operator-config"
+
+	//handlers
+	RookSecretHandlerName = "rook"
+	S3SecretHandlerName   = "s3"
+	DRModeAnnotationKey   = "multicluster.openshift.io/mode"
 )
 
 func GetCurrentStorageClusterRef(mp *multiclusterv1alpha1.MirrorPeer, spokeClusterName string) (*multiclusterv1alpha1.StorageClusterRef, error) {

--- a/tests/integration/managedclusteraddon_test.go
+++ b/tests/integration/managedclusteraddon_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*
@@ -63,6 +64,7 @@ var _ = Describe("ManagedClusterAddOn creation, updation and deletion", func() {
 		BeforeEach(func() {
 			newMirrorPeer := mirrorPeer1.DeepCopy()
 			newMirrorPeer.Spec = multiclusterv1alpha1.MirrorPeerSpec{
+				Type: "async",
 				Items: []multiclusterv1alpha1.PeerRef{
 					{
 						ClusterName: "cluster1",

--- a/tests/integration/mirrorpeer_controller_test.go
+++ b/tests/integration/mirrorpeer_controller_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /*
@@ -64,6 +65,7 @@ var _ = Describe("MirrorPeer Validations", func() {
 			By("creating MirrorPeer with 1 Item", func() {
 				newMirrorPeer := mirrorPeer.DeepCopy()
 				newMirrorPeer.Spec = multiclusterv1alpha1.MirrorPeerSpec{
+					Type: "async",
 					Items: []multiclusterv1alpha1.PeerRef{
 						{
 							ClusterName: "test-provider-cluster",
@@ -80,6 +82,7 @@ var _ = Describe("MirrorPeer Validations", func() {
 			By("creating MirrorPeer without MirrorPeer.Spec.Items[*].ClusterName ", func() {
 				newMirrorPeer := mirrorPeer.DeepCopy()
 				newMirrorPeer.Spec = multiclusterv1alpha1.MirrorPeerSpec{
+					Type: "async",
 					Items: []multiclusterv1alpha1.PeerRef{
 						{
 							StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
@@ -105,6 +108,7 @@ var _ = Describe("MirrorPeer Validations", func() {
 			By("creating MirrorPeer without MirrorPeer.Spec.Items[*].StorageClusterRef ", func() {
 				newMirrorPeer := mirrorPeer.DeepCopy()
 				newMirrorPeer.Spec = multiclusterv1alpha1.MirrorPeerSpec{
+					Type: "async",
 					Items: []multiclusterv1alpha1.PeerRef{
 						{
 							ClusterName: "test-provider-cluster1",
@@ -128,6 +132,7 @@ var _ = Describe("MirrorPeer Validations", func() {
 			By("creating MirrorPeer with all fields well defined", func() {
 				newMirrorPeer := mirrorPeer.DeepCopy()
 				newMirrorPeer.Spec = multiclusterv1alpha1.MirrorPeerSpec{
+					Type: "async",
 					Items: []multiclusterv1alpha1.PeerRef{
 						{
 							ClusterName: "test-provider-cluster1",
@@ -157,6 +162,7 @@ var _ = Describe("MirrorPeer Validations", func() {
 		BeforeEach(func() {
 			newMirrorPeer := mirrorPeer.DeepCopy()
 			newMirrorPeer.Spec = multiclusterv1alpha1.MirrorPeerSpec{
+				Type: "async",
 				Items: []multiclusterv1alpha1.PeerRef{
 					{
 						ClusterName: "test-provider-cluster1",
@@ -256,6 +262,7 @@ var _ = Describe("MirrorPeerReconciler Reconcile", func() {
 
 			newMirrorPeer := mirrorPeer.DeepCopy()
 			newMirrorPeer.Spec = multiclusterv1alpha1.MirrorPeerSpec{
+				Type: "async",
 				Items: []multiclusterv1alpha1.PeerRef{
 					{
 						ClusterName: "test-provider-cluster1",

--- a/tests/integration/mirrorpeer_status_test.go
+++ b/tests/integration/mirrorpeer_status_test.go
@@ -62,6 +62,7 @@ var _ = Describe("MirrorPeer Status Tests", func() {
 				Name: "fake-mirror-peer-2",
 			},
 			Spec: multiclusterv1alpha1.MirrorPeerSpec{
+				Type: "async",
 				Items: []multiclusterv1alpha1.PeerRef{
 					{
 						ClusterName: "new-managed-cluster-1",
@@ -151,6 +152,7 @@ var _ = Describe("MirrorPeer Status Tests", func() {
 				Name: "fake-mirror-peer",
 			},
 			Spec: multiclusterv1alpha1.MirrorPeerSpec{
+				Type: "async",
 				Items: []multiclusterv1alpha1.PeerRef{
 					{
 						ClusterName: "managed-cluster1",

--- a/tests/integration/mirrorpeersecret_controller_test.go
+++ b/tests/integration/mirrorpeersecret_controller_test.go
@@ -138,6 +138,7 @@ var _ = Describe("MirrorPeerSecret Controller", func() {
 				Name: mpName,
 			},
 			Spec: multiclusterv1alpha1.MirrorPeerSpec{
+				Type:  "async",
 				Items: items,
 			},
 		}


### PR DESCRIPTION
This commit adds support for Metro DR (sync mode)
The following changes are added -
1. Add DRType to MirrorPeer (sync/asyn)
2. Add annotation to ManagedClusterAddon for custom handlers
3. Changes to test to include DRType for MirrorPeer
4. Changes to spoke deployment and addition of handlers flag
5. Sync = S3ProfileSync only, Async = Just like before 


https://issues.redhat.com/browse/RHSTOR-2542

