### PR TITLE
Delete resources while deleting MirrorPeer

### DIFF
--- a/addons/token-exchange/agent_mirrorpeer_controller.go
+++ b/addons/token-exchange/agent_mirrorpeer_controller.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"strconv"
 
 	replicationv1alpha1 "github.com/csi-addons/volume-replication-operator/api/v1alpha1"
 	obv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
@@ -66,6 +67,7 @@ const (
 	StorageIDKey                          = "storageid"
 	ReplicationIDKey                      = "replicationid"
 	CephFSProvisionerTemplate             = "%s.cephfs.csi.ceph.com"
+	SpokeMirrorPeerFinalizer              = "spoke.mirrorpeer.multicluster.odf.openshift.io"
 )
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -74,7 +76,7 @@ const (
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	klog.Infof("Running MirrorPeer reconciler on  spoke cluster")
+	klog.Infof("Running MirrorPeer reconciler on spoke cluster")
 	// Fetch MirrorPeer for given Request
 	var mirrorPeer multiclusterv1alpha1.MirrorPeer
 	err := r.HubClient.Get(ctx, req.NamespacedName, &mirrorPeer)
@@ -86,10 +88,72 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		klog.Error(err, "Failed to get MirrorPeer")
 		return ctrl.Result{}, err
 	}
+
 	scr, err := utils.GetCurrentStorageClusterRef(&mirrorPeer, r.SpokeClusterName)
 	if err != nil {
 		klog.Error(err, "Failed to get current storage cluster ref")
 		return ctrl.Result{}, err
+	}
+
+	agentFinalizer := r.SpokeClusterName + "." + SpokeMirrorPeerFinalizer
+
+	if mirrorPeer.GetDeletionTimestamp().IsZero() {
+		if !utils.ContainsString(mirrorPeer.GetFinalizers(), agentFinalizer) {
+			klog.Infof("Finalizer not found on MirrorPeer. Adding Finalizer %q", agentFinalizer)
+			mirrorPeer.Finalizers = append(mirrorPeer.Finalizers, agentFinalizer)
+			if err := r.HubClient.Update(ctx, &mirrorPeer); err != nil {
+				klog.Errorf("Failed to add finalizer to MirrorPeer %q", mirrorPeer.Name)
+				return ctrl.Result{}, err
+			}
+		}
+	} else {
+		klog.Infof("Mirrorpeer is being deleted %q", mirrorPeer.Name)
+		peerRef, err := utils.GetPeerRefForSpokeCluster(&mirrorPeer, r.SpokeClusterName)
+		if err != nil {
+			klog.Errorf("Failed to get current PeerRef %q %v", mirrorPeer.Name, err)
+			return ctrl.Result{}, err
+		}
+
+		peerRefUsed, err := utils.DoesAnotherMirrorPeerPointToPeerRef(ctx, r.HubClient, peerRef)
+		if err != nil {
+			klog.Errorf("failed to check if another peer uses peer ref %v", err)
+		}
+		if !peerRefUsed {
+			if err := r.disableMirroring(ctx, scr.Name, scr.Namespace, &mirrorPeer); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to disable mirroring for the storagecluster %q in namespace %q. Error %v", scr.Name, scr.Namespace, err)
+			}
+			if err := r.disableCSIAddons(ctx, scr.Namespace); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to disable CSI Addons for rook: %v", err)
+			}
+		}
+
+		if err := r.deleteGreenSecret(ctx, r.SpokeClusterName, scr.Namespace, &mirrorPeer); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete green secrets: %v", err)
+		}
+
+		if err := r.deleteVolumeReplicationClass(ctx, &mirrorPeer, peerRef); err != nil {
+			return ctrl.Result{}, fmt.Errorf("few failures occured while deleting VolumeReplicationClasses: %v", err)
+		}
+		if err := r.deleteS3(ctx, mirrorPeer, scr.Namespace); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete s3 buckets")
+		}
+		err = r.HubClient.Get(ctx, req.NamespacedName, &mirrorPeer)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				klog.Info("Could not find MirrorPeer. Ignoring since object must have been deleted")
+				return ctrl.Result{}, nil
+			}
+			klog.Error(err, "Failed to get MirrorPeer")
+			return ctrl.Result{}, err
+		}
+		mirrorPeer.Finalizers = utils.RemoveString(mirrorPeer.Finalizers, agentFinalizer)
+
+		if err := r.HubClient.Update(ctx, &mirrorPeer); err != nil {
+			klog.Error("failed to remove finalizer from MirrorPeer ", err)
+			return ctrl.Result{}, err
+		}
+		klog.Info("MirrorPeer deleted, skipping reconcilation")
+		return ctrl.Result{}, nil
 	}
 
 	clusterFSIDs := make(map[string]string)
@@ -135,31 +199,7 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 }
 
 func (r *MirrorPeerReconciler) createS3(ctx context.Context, req ctrl.Request, mirrorPeer multiclusterv1alpha1.MirrorPeer, scNamespace string) error {
-	var err error
-
-	var peerAccumulator string
-	for _, peer := range mirrorPeer.Spec.Items {
-		peerAccumulator += peer.ClusterName
-	}
-	checksum := sha1.Sum([]byte(peerAccumulator))
-
-	bucketGenerateName := utils.BucketGenerateName
-	// truncate to bucketGenerateName + "-" + first 12 (out of 20) byte representations of sha1 checksum
-	bucket := fmt.Sprintf("%s-%s", bucketGenerateName, hex.EncodeToString(checksum[:]))[0 : len(bucketGenerateName)+1+12]
-
-	namespace := utils.GetEnv("ODR_NAMESPACE", scNamespace)
-
-	noobaaOBC := &obv1alpha1.ObjectBucketClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      bucket,
-			Namespace: namespace,
-		},
-		Spec: obv1alpha1.ObjectBucketClaimSpec{
-			BucketName:       bucket,
-			StorageClassName: namespace + ".noobaa.io",
-		},
-	}
-	err = r.SpokeClient.Get(ctx, types.NamespacedName{Name: bucket, Namespace: namespace}, noobaaOBC)
+	noobaaOBC, err := r.getS3bucket(ctx, mirrorPeer, scNamespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			klog.Info("Could not find ODR ObjectBucketClaim, creating")
@@ -176,7 +216,39 @@ func (r *MirrorPeerReconciler) createS3(ctx context.Context, req ctrl.Request, m
 	return err
 }
 
+func (r *MirrorPeerReconciler) getS3bucket(ctx context.Context, mirrorPeer multiclusterv1alpha1.MirrorPeer, scNamespace string) (*obv1alpha1.ObjectBucketClaim, error) {
+	var peerAccumulator string
+	for _, peer := range mirrorPeer.Spec.Items {
+		peerAccumulator += peer.ClusterName
+	}
+	checksum := sha1.Sum([]byte(peerAccumulator))
+
+	bucketGenerateName := utils.BucketGenerateName
+	// truncate to bucketGenerateName + "-" + first 12 (out of 20) byte representations of sha1 checksum
+	bucket := fmt.Sprintf("%s-%s", bucketGenerateName, hex.EncodeToString(checksum[:]))[0 : len(bucketGenerateName)+1+12]
+	namespace := utils.GetEnv("ODR_NAMESPACE", scNamespace)
+
+	noobaaOBC := &obv1alpha1.ObjectBucketClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bucket,
+			Namespace: namespace,
+		},
+		Spec: obv1alpha1.ObjectBucketClaimSpec{
+			BucketName:       bucket,
+			StorageClassName: namespace + ".noobaa.io",
+		},
+	}
+	err := r.SpokeClient.Get(ctx, types.NamespacedName{Name: bucket, Namespace: namespace}, noobaaOBC)
+	return noobaaOBC, err
+}
+
+// enableMirroring is a wrapper function around toggleMirroring to enable mirroring in a storage cluster
 func (r *MirrorPeerReconciler) enableMirroring(ctx context.Context, storageClusterName string, namespace string, mp *multiclusterv1alpha1.MirrorPeer) error {
+	return r.toggleMirroring(ctx, storageClusterName, namespace, true, mp)
+}
+
+// toggleMirroring changes the state of mirroring in the storage cluster
+func (r *MirrorPeerReconciler) toggleMirroring(ctx context.Context, storageClusterName string, namespace string, enabled bool, mp *multiclusterv1alpha1.MirrorPeer) error {
 	var sc ocsv1.StorageCluster
 	err := r.SpokeClient.Get(ctx, types.NamespacedName{
 		Name:      storageClusterName,
@@ -189,13 +261,17 @@ func (r *MirrorPeerReconciler) enableMirroring(ctx context.Context, storageClust
 		}
 		return err
 	}
-	oppPeers := getOppositePeerRefs(mp, r.SpokeClusterName)
-	if hasRequiredSecret(sc.Spec.Mirroring.PeerSecretNames, oppPeers) {
-
-		sc.Spec.Mirroring.Enabled = true
-		klog.Info("Enabled mirroring on StorageCluster ", storageClusterName)
+	if enabled {
+		oppPeers := getOppositePeerRefs(mp, r.SpokeClusterName)
+		if hasRequiredSecret(sc.Spec.Mirroring.PeerSecretNames, oppPeers) {
+			sc.Spec.Mirroring.Enabled = true
+			klog.Info("Enabled mirroring on StorageCluster ", storageClusterName)
+		} else {
+			klog.Error(err, "StorageCluster does not have required PeerSecrets")
+			return err
+		}
 	} else {
-		klog.Error(err, "StorageCluster does not have required PeerSecrets")
+		sc.Spec.Mirroring.Enabled = false
 	}
 	return r.SpokeClient.Update(ctx, &sc)
 }
@@ -212,13 +288,24 @@ func getOppositePeerRefs(mp *multiclusterv1alpha1.MirrorPeer, spokeClusterName s
 func hasRequiredSecret(peerSecrets []string, oppositePeerRef []multiclusterv1alpha1.PeerRef) bool {
 	for _, pr := range oppositePeerRef {
 		sec := utils.GetSecretNameByPeerRef(pr)
-		if !contains(peerSecrets, sec) {
+		if !utils.ContainsString(peerSecrets, sec) {
 			return false
 		}
 	}
 	return true
 }
 func (r *MirrorPeerReconciler) enableCSIAddons(ctx context.Context, namespace string) error {
+	err := r.toggleCSIAddons(ctx, namespace, true)
+	if err != nil {
+		klog.Error(err, "failed to enable CSI addons")
+		return err
+	} else {
+		klog.Info("CSI addons enabled successfully ")
+	}
+	return nil
+}
+
+func (r *MirrorPeerReconciler) toggleCSIAddons(ctx context.Context, namespace string, enabled bool) error {
 	var rcm corev1.ConfigMap
 	err := r.SpokeClient.Get(ctx, types.NamespacedName{
 		Name:      RookConfigMapName,
@@ -232,18 +319,10 @@ func (r *MirrorPeerReconciler) enableCSIAddons(ctx context.Context, namespace st
 		return err
 	}
 
-	rcm.Data[RookCSIEnableKey] = "true"
-	rcm.Data[RookVolumeRepKey] = "true"
+	rcm.Data[RookCSIEnableKey] = strconv.FormatBool(enabled)
+	rcm.Data[RookVolumeRepKey] = strconv.FormatBool(enabled)
 
-	err = r.SpokeClient.Update(ctx, &rcm)
-	if err != nil {
-		klog.Error(err, "Failed to enable CSI addons")
-		return err
-	} else {
-		klog.Info("CSI addons enabled successfully ")
-	}
-
-	return nil
+	return r.SpokeClient.Update(ctx, &rcm)
 }
 
 func (r *MirrorPeerReconciler) fetchClusterFSIDs(ctx context.Context, mp *multiclusterv1alpha1.MirrorPeer, clusterFSIDs map[string]string) error {
@@ -407,4 +486,131 @@ func (r *MirrorPeerReconciler) labelRBDStorageClasses(ctx context.Context, mp mu
 	}
 
 	return errs
+}
+
+func (r *MirrorPeerReconciler) disableMirroring(ctx context.Context, storageClusterName string, namespace string, mp *multiclusterv1alpha1.MirrorPeer) error {
+	return r.toggleMirroring(ctx, storageClusterName, namespace, false, mp)
+}
+
+func (r *MirrorPeerReconciler) disableCSIAddons(ctx context.Context, namespace string) error {
+	err := r.toggleCSIAddons(ctx, namespace, false)
+	if err != nil {
+		klog.Error(err, "Failed to disable CSI addons")
+		return err
+	} else {
+		klog.Info("CSI addons disabled successfully ")
+	}
+	return nil
+}
+
+// deleteGreenSecret deletes the exchanged secret present in the namespace of the storage cluster
+func (r *MirrorPeerReconciler) deleteGreenSecret(ctx context.Context, spokeClusterName string, scrNamespace string, mirrorPeer *multiclusterv1alpha1.MirrorPeer) error {
+	for _, peerRef := range mirrorPeer.Spec.Items {
+		if peerRef.ClusterName != spokeClusterName {
+			secretName := utils.GetSecretNameByPeerRef(peerRef)
+			secret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: scrNamespace,
+				},
+			}
+			if err := r.SpokeClient.Delete(ctx, &secret); err != nil {
+				if errors.IsNotFound(err) {
+					klog.Info("failed to find green secret ", secretName)
+					return nil
+				} else {
+					klog.Error(err, "failed to delete green secret ", secretName)
+					return err
+				}
+			}
+			klog.Info("Succesfully deleted ", secretName, " in namespace ", scrNamespace)
+		}
+	}
+	return nil
+}
+
+// deleteS3 deletes the S3 bucket in the storage cluster namespace, each new mirrorpeer generates
+// a new bucket, so we do not need to check if the bucket is being used by another mirrorpeer
+func (r *MirrorPeerReconciler) deleteS3(ctx context.Context, mirrorPeer multiclusterv1alpha1.MirrorPeer, scNamespace string) error {
+	noobaaOBC, err := r.getS3bucket(ctx, mirrorPeer, scNamespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.Info("Could not find ODR ObjectBucketClaim, skipping deletion")
+			return nil
+		} else {
+			klog.Error(err, "Failed to get ODR ObjectBucketClaim")
+			return err
+		}
+	}
+	err = r.SpokeClient.Delete(ctx, noobaaOBC)
+	if err != nil {
+		klog.Error(err, "Failed to delete ODR ObjectBucketClaim")
+		return err
+	}
+	return err
+}
+
+// deleteVolumeReplicationClass deletes the volume replication class present in the storage cluster resource,
+// we check if another mirrorpeer is using the same scheduling interval while pointing to the same peer ref
+func (r *MirrorPeerReconciler) deleteVolumeReplicationClass(ctx context.Context, mp *multiclusterv1alpha1.MirrorPeer, peerRef *multiclusterv1alpha1.PeerRef) error {
+	for _, interval := range mp.Spec.SchedulingIntervals {
+		intervalUsed, err := utils.DoesAnotherMirrorPeerContainTheSchedulingInterval(ctx, r.HubClient, mp, interval, peerRef)
+		if err != nil {
+			return err
+		}
+		if intervalUsed {
+			return nil
+		}
+
+		vrcName := fmt.Sprintf(RBDVolumeReplicationClassNameTemplate, utils.FnvHash(interval))
+
+		vrc := &replicationv1alpha1.VolumeReplicationClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: vrcName,
+			},
+		}
+		err = r.SpokeClient.Delete(ctx, vrc)
+		if errors.IsNotFound(err) {
+			klog.Error("Cannot find volume replication class for interval", interval, " ", err)
+			return nil
+		}
+
+		klog.Info("Succesfully deleted interval ", interval)
+
+	}
+	return nil
+}
+
+func (r *MirrorPeerReconciler) deleteMirrorPeer(ctx context.Context, mirrorPeer multiclusterv1alpha1.MirrorPeer, scr *multiclusterv1alpha1.StorageClusterRef) (ctrl.Result, error) {
+	klog.Infof("Mirrorpeer is being deleted %q", mirrorPeer.Name)
+	peerRef, err := utils.GetPeerRefForSpokeCluster(&mirrorPeer, r.SpokeClusterName)
+	if err != nil {
+		klog.Errorf("Failed to get current PeerRef %q %v", mirrorPeer.Name, err)
+		return ctrl.Result{}, err
+	}
+
+	peerRefUsed, err := utils.DoesAnotherMirrorPeerPointToPeerRef(ctx, r.HubClient, peerRef)
+	if err != nil {
+		klog.Errorf("failed to check if another peer uses peer ref %v", err)
+	}
+	if !peerRefUsed {
+		if err := r.disableMirroring(ctx, scr.Name, scr.Namespace, &mirrorPeer); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to disable mirroring for the storagecluster %q in namespace %q. Error %v", scr.Name, scr.Namespace, err)
+		}
+		if err := r.disableCSIAddons(ctx, scr.Namespace); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to disable CSI Addons for rook: %v", err)
+		}
+	}
+
+	if err := r.deleteGreenSecret(ctx, r.SpokeClusterName, scr.Namespace, &mirrorPeer); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to delete green secrets: %v", err)
+	}
+
+	if err := r.deleteVolumeReplicationClass(ctx, &mirrorPeer, peerRef); err != nil {
+		return ctrl.Result{}, fmt.Errorf("few failures occured while deleting VolumeReplicationClasses: %v", err)
+	}
+	if err := r.deleteS3(ctx, mirrorPeer, scr.Namespace); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to delete s3 buckets")
+	}
+	return ctrl.Result{}, nil
 }

--- a/addons/token-exchange/manifests/spoke_clusterrole.yaml
+++ b/addons/token-exchange/manifests/spoke_clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: ["objectbucket.io"]
   resources: ["objectbucketclaims"]
-  verbs: ["get", "create",]
+  verbs: ["get", "create", "delete"]
 - apiGroups: ["multicluster.odf.openshift.io"]
   resources: ["mirrorpeers"]
   verbs: ["get", "list", "watch", "update"]

--- a/addons/token-exchange/rook_secret_handler.go
+++ b/addons/token-exchange/rook_secret_handler.go
@@ -168,7 +168,7 @@ func updateStorageCluster(secretName, storageClusterName, storageClusterNamespac
 	}
 
 	// Update secret name
-	if !contains(sc.Spec.Mirroring.PeerSecretNames, secretName) {
+	if !utils.ContainsString(sc.Spec.Mirroring.PeerSecretNames, secretName) {
 		sc.Spec.Mirroring.PeerSecretNames = append(sc.Spec.Mirroring.PeerSecretNames, secretName)
 		err := spokeClient.Update(ctx, sc)
 		if err != nil {
@@ -177,14 +177,4 @@ func updateStorageCluster(secretName, storageClusterName, storageClusterNamespac
 	}
 
 	return nil
-}
-
-// contains checks if an item exists in a given list.
-func contains(list []string, s string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }

--- a/api/v1alpha1/mirrorpeer_types.go
+++ b/api/v1alpha1/mirrorpeer_types.go
@@ -26,6 +26,7 @@ type DRType string
 const (
 	ExchangingSecret PhaseType = "ExchangingSecret"
 	ExchangedSecret  PhaseType = "ExchangedSecret"
+	Deleting         PhaseType = "Deleting"
 	Sync             DRType    = "sync"
 	Async            DRType    = "async"
 )

--- a/controllers/utils/peer_ref.go
+++ b/controllers/utils/peer_ref.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DoesAnotherMirrorPeerPointToPeerRef checks if another mirrorpeer is pointing to the provided peer ref
+func DoesAnotherMirrorPeerPointToPeerRef(ctx context.Context, rc client.Client, peerRef *multiclusterv1alpha1.PeerRef) (bool, error) {
+	mirrorPeers, err := FetchAllMirrorPeers(ctx, rc)
+	if err != nil {
+		return false, err
+	}
+	count := 0
+	for i := range mirrorPeers {
+		if ContainsPeerRef(mirrorPeers[i].Spec.Items, peerRef) {
+			count++
+		}
+	}
+
+	return count > 1, nil
+}
+
+// DoesAnotherMirrorPeerContainTheSchedulingInterval checks if a scheduling interval is being used by another mirrorpeer pointing to the same peer ref
+func DoesAnotherMirrorPeerContainTheSchedulingInterval(ctx context.Context, rc client.Client, current *multiclusterv1alpha1.MirrorPeer, schedulingInterval string, peerRef *multiclusterv1alpha1.PeerRef) (bool, error) {
+	mirrorPeers, err := FetchAllMirrorPeers(ctx, rc)
+	if err != nil {
+		return false, err
+	}
+	mirrorPeers = RemoveMirrorPeer(mirrorPeers, *current)
+	for i := range mirrorPeers {
+		if ContainsString(mirrorPeers[i].Spec.SchedulingIntervals, schedulingInterval) && ContainsPeerRef(mirrorPeers[i].Spec.Items, peerRef) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// GetPeerRefForSpokeCluster returns the peer ref for the cluster name
+func GetPeerRefForSpokeCluster(mp *multiclusterv1alpha1.MirrorPeer, spokeClusterName string) (*multiclusterv1alpha1.PeerRef, error) {
+	for _, v := range mp.Spec.Items {
+		if v.ClusterName == spokeClusterName {
+			return &v, nil
+		}
+	}
+	return nil, fmt.Errorf("PeerRef for cluster %s under mirrorpeer %s not found", spokeClusterName, mp.Name)
+}

--- a/controllers/utils/slice.go
+++ b/controllers/utils/slice.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"reflect"
+	"strings"
+
+	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
+)
+
+// ContainsString checks if a slice of strings contains the provided string
+func ContainsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func ContainsSuffix(slice []string, s string) bool {
+	for _, item := range slice {
+		if strings.HasSuffix(item, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsPeerRef checks if a slice of PeerRef contains the provided PeerRef
+func ContainsPeerRef(slice []multiclusterv1alpha1.PeerRef, peerRef *multiclusterv1alpha1.PeerRef) bool {
+	for i := range slice {
+		if reflect.DeepEqual(slice[i], *peerRef) {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveString removes a given string from a slice and returns the new slice
+func RemoveString(slice []string, s string) (result []string) {
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}
+
+// RemoveMirrorPeer removes the given mirrorPeer from the slice and returns the new slice
+func RemoveMirrorPeer(slice []multiclusterv1alpha1.MirrorPeer, mirrorPeer multiclusterv1alpha1.MirrorPeer) (result []multiclusterv1alpha1.MirrorPeer) {
+	for _, item := range slice {
+		if item.Name == mirrorPeer.Name {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
-	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -95,7 +95,7 @@ require (
 	github.com/noobaa/noobaa-operator/v5 v5.0.0-20220412093540-8972af85cac4 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 // indirect
-	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca // indirect
+	github.com/openshift/custom-resource-status v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1017,8 +1017,9 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.7/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
 github.com/go-openapi/swag v0.19.9/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
 github.com/go-openapi/swag v0.19.10/go.mod h1:Uc0gKkdR+ojzsEpjh39QChyu92vPgIr72POcgHMAgSY=
-github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-openapi/swag v0.19.15 h1:D2NRCBzS9/pEY3gP9Nl8aDqGUcPFrwG2p+CNFrLyrCM=
+github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.3/go.mod h1:90Vh6jjkTn+OT1Eefm0ZixWNFjhtOH7vS9k0lo6zwJo=
@@ -2339,8 +2340,9 @@ github.com/openshift/cluster-autoscaler-operator v0.0.0-20190521201101-62768a6ba
 github.com/openshift/custom-resource-status v0.0.0-20190801200128-4c95b3a336cd/go.mod h1:5FN5ZOa6szVg6C3kB6PbSL6VHAbX5+HpLvGZhUCJmKs=
 github.com/openshift/custom-resource-status v0.0.0-20190812200727-7961da9a2eb7/go.mod h1:5FN5ZOa6szVg6C3kB6PbSL6VHAbX5+HpLvGZhUCJmKs=
 github.com/openshift/custom-resource-status v0.0.0-20190822192428-e62f2f3b79f3/go.mod h1:GDjWl0tX6FNIj82vIxeudWeSx2Ff6nDZ8uJn0ohUFvo=
-github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca h1:F1MEnOMwSrTA0YAkO0he9ip9w0JhYzI/iCB2mXmaSPg=
 github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca/go.mod h1:GDjWl0tX6FNIj82vIxeudWeSx2Ff6nDZ8uJn0ohUFvo=
+github.com/openshift/custom-resource-status v1.1.0 h1:EjSh0f3vF6eaS3zAToVHUXcS7N2jVEosUFJ0sRKvmZ0=
+github.com/openshift/custom-resource-status v1.1.0/go.mod h1:GDjWl0tX6FNIj82vIxeudWeSx2Ff6nDZ8uJn0ohUFvo=
 github.com/openshift/generic-admission-server v1.14.1-0.20200903115324-4ddcdd976480/go.mod h1:OAHL5WnZphlhVEf5fTdeGLvNwMu1B2zCWpmxJpCA35o=
 github.com/openshift/hive v1.1.16/go.mod h1:QJY97wHcEv7LTCB5tStmo9JT6E2LHSF8m73fFVz/Aj8=
 github.com/openshift/hive/apis v0.0.0-20211028175624-6c9c8e4bff7f/go.mod h1:77ODrnaHiDlfbqQgvk5nUWuqf2AsGY/99QlfNTiqHwI=


### PR DESCRIPTION
This PR adds the deletion workflow to the MCO, The manager pod and the token exchange pod add a finalizer to the mirrorpeer to allow for things to get deleted. 
- ManagedClusterAddon gets added with owner refs to the MirrorPeer
- The manager controller first waits for the agent to remove its finalizer, then goes ahead and delete's the PeerRef's Secret if it's not being used any other MirrorPeer.
- The agent also checks if the PeerRef is being used by another MirrorPeer, if it's not then it disables mirroring and CSI addons volume replication
    - Delete the volume replication classes based the scheduling intervals and if it's being used or not
    - Deletes the green s3 secrets in the storage cluster namespace
    - Deletes s3 buckets based on the combination of peerRefs in the MirrorPeer