### PR TITLE
Label VRCs and RBD StorageClasses with Ramen Labels

### DIFF
--- a/addons/token-exchange/manifests/spoke_clusterrole.yaml
+++ b/addons/token-exchange/manifests/spoke_clusterrole.yaml
@@ -24,3 +24,6 @@ rules:
 - apiGroups: ["multicluster.odf.openshift.io"]
   resources: ["mirrorpeers"]
   verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get","list","update"]

--- a/controllers/utils/hash.go
+++ b/controllers/utils/hash.go
@@ -33,3 +33,7 @@ func CreateUniqueSecretName(managedCluster, storageClusterNamespace, storageClus
 	}
 	return CreateUniqueName(managedCluster, storageClusterNamespace, storageClusterName)[0:39]
 }
+
+func CreateUniqueReplicationId(fsids []string) string {
+	return CreateUniqueName(fsids...)[0:39]
+}


### PR DESCRIPTION
This commit does the following things
1. Agent MirrorPeer controller labels the RBD StorageClasses with these
   FSID for each managedcluster
2. Agent MirrorPeer controller labels the VRC with replicationids
   generated through FSIDs of each managed cluster
