### PR TITLE
No more watch errors (Hopefully!)

### DIFF
--- a/addons/token-exchange/manifests/spoke_clusterrole.yaml
+++ b/addons/token-exchange/manifests/spoke_clusterrole.yaml
@@ -21,3 +21,6 @@ rules:
 - apiGroups: ["objectbucket.io"]
   resources: ["objectbucketclaims"]
   verbs: ["get", "create",]
+- apiGroups: ["multicluster.odf.openshift.io"]
+  resources: ["mirrorpeers"]
+  verbs: ["get", "list", "watch", "update"]

--- a/addons/token-exchange/manifests/spoke_clusterrolebinding.yaml
+++ b/addons/token-exchange/manifests/spoke_clusterrolebinding.yaml
@@ -10,3 +10,9 @@ subjects:
 - kind: ServiceAccount
   name: token-exchange-agent-sa
   namespace: {{ .AddonInstallNamespace }}
+- kind: User
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ .User }}
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ .Group }}

--- a/addons/token-exchange/token_exchanger_addon.go
+++ b/addons/token-exchange/token_exchanger_addon.go
@@ -72,18 +72,25 @@ func (a *TokenExchangeAddon) Manifests(cluster *clusterv1.ManagedCluster, addon 
 		return objects, fmt.Errorf("image not provided for agent %q", TokenExchangeName)
 	}
 
+	groups := agent.DefaultGroups(cluster.Name, TokenExchangeName)
+	user := agent.DefaultUser(cluster.Name, TokenExchangeName, TokenExchangeName)
+
 	manifestConfig := struct {
 		KubeConfigSecret      string
 		ClusterName           string
 		AddonInstallNamespace string
 		Image                 string
 		DRMode                string
+		Group                 string
+		User                  string
 	}{
 		KubeConfigSecret:      fmt.Sprintf("%s-hub-kubeconfig", TokenExchangeName),
 		AddonInstallNamespace: installNamespace,
 		ClusterName:           cluster.Name,
 		Image:                 a.AgentImage,
 		DRMode:                addon.Annotations[utils.DRModeAnnotationKey],
+		Group:                 groups[0],
+		User:                  user,
 	}
 
 	for _, file := range agentDeploymentFiles {


### PR DESCRIPTION
This commit adds permission to spokeclusterrole and bindings to give
MirrorPeer watch permissions to the default agent user

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>