### PR TITLE
Fix sync mode and fail if it is invalid

### DIFF
--- a/addons/token-exchange/secret_exchange_handler_register.go
+++ b/addons/token-exchange/secret_exchange_handler_register.go
@@ -52,6 +52,8 @@ func registerHandler(mode multiclusterv1alpha1.DRType, spokeKubeConfig *rest.Con
 			spokeClient: genericSpokeClient,
 			hubClient:   genericHubClient,
 		}
+	default:
+		return fmt.Errorf("unsupported DR mode: %v", mode)
 	}
 
 	return nil

--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -142,13 +142,13 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	// Create or Update ManagedClusterAddon
 	for i := range mirrorPeer.Spec.Items {
+		annotations := make(map[string]string)
+		annotations[utils.DRModeAnnotationKey] = string(mirrorPeer.Spec.Type)
 		managedClusterAddOn := addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      tokenexchange.TokenExchangeName,
-				Namespace: mirrorPeer.Spec.Items[i].ClusterName,
-				Annotations: map[string]string{
-					utils.DRModeAnnotationKey: string(mirrorPeer.Spec.Type),
-				},
+				Name:        tokenexchange.TokenExchangeName,
+				Namespace:   mirrorPeer.Spec.Items[i].ClusterName,
+				Annotations: annotations,
 			},
 		}
 		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &managedClusterAddOn, func() error {

--- a/tests/integration/managedclusteraddon_test.go
+++ b/tests/integration/managedclusteraddon_test.go
@@ -29,6 +29,7 @@ import (
 
 	tokenexchange "github.com/red-hat-storage/odf-multicluster-orchestrator/addons/token-exchange"
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -153,6 +154,18 @@ var _ = Describe("ManagedClusterAddOn creation, updation and deletion", func() {
 					k8sClient.Get(context.TODO(), mcAddOn1LookupKey, &mcAddOn1)
 					return mcAddOn1.Spec.InstallNamespace
 				}, 20*time.Second, 2*time.Second).Should(Equal("new-test-namespace"))
+			})
+
+			By("having invalid annotations", func() {
+				Eventually(func() string {
+					k8sClient.Get(context.TODO(), mcAddOn1LookupKey, &mcAddOn1)
+					return mcAddOn1.Annotations[utils.DRModeAnnotationKey]
+				}, 20*time.Second, 2*time.Second).Should(Equal("async"))
+
+				Eventually(func() string {
+					k8sClient.Get(context.TODO(), mcAddOn2LookupKey, &mcAddOn2)
+					return mcAddOn2.Annotations[utils.DRModeAnnotationKey]
+				}, 20*time.Second, 2*time.Second).Should(Equal("async"))
 			})
 		})
 	})


### PR DESCRIPTION
This commit fixes a bug where the annotations are not correctly passed
to managedclusteraddon and it does not fail if it is invalid.

It also updates the integration tests to check the presence and validity of the
annotations

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>