### PR TITLE
update CI workflows and dependencies

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,31 +14,34 @@ defaults:
 
 jobs:
   golangci-lint:
+    name: Go ${{ matrix.go }} Lint
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.16.x]
-
-    name: Go
-    runs-on: ubuntu-latest
+        go: [ '1.16', '1.17' ]
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go }}
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.41.1
-        only-new-issues: true
+        version: v1.45.2
 
   kube-linter:
     name: Kube YAML
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Lint
-      uses: stackrox/kube-linter-action@v1.0.2
+      uses: stackrox/kube-linter-action@v1.0.4
       with:
         directory: config/
         config: .kube-linter-config.yaml

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -9,9 +9,6 @@ on:
     branches: [main]
     types: [completed]
 
-env:
-  GO_VERSION: "1.16"
-
 defaults:
   run:
     shell: bash
@@ -20,15 +17,18 @@ jobs:
   publish-operator:
     name: Operator Image
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16' ]
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go }}
 
     - name: Build
       run: make docker-build
@@ -47,15 +47,18 @@ jobs:
     name: Bundle Image
     needs: publish-operator
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16' ]
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go }}
 
     - name: Build
       run: make bundle-build
@@ -74,15 +77,18 @@ jobs:
     name: Catalog Image
     needs: publish-bundle
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16' ]
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go }}
 
     - name: Build
       run: make catalog-build

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ '*' ]
 
-env:
-  GO_VERSION: "1.16"
-
 defaults:
   run:
     shell: bash
@@ -17,30 +14,36 @@ jobs:
   clean-workdir:
     name: Ensure Clean Workdir
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.17' ]
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go }}
 
     - name: Scan for uncommitted changes
       run: make ensure-clean-workdir
 
   unit-test:
-    name: Unit Tests
+    name: Unit Tests (Go ${{ matrix.go }})
     needs: clean-workdir
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.17' ]
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go }}
 
     - name: Run unit tests
       run: make unit-test
@@ -49,14 +52,17 @@ jobs:
     name: Integration Tests
     needs: clean-workdir
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.17' ]
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go }}
 
     - name: Run integration tests
       run: make test
@@ -65,14 +71,17 @@ jobs:
     name: Build Operator Image
     needs: [unit-test,integration-test]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.17' ]
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go }}
 
     - name: Build
       run: make docker-build
@@ -81,14 +90,17 @@ jobs:
     name: Validate Operator Bundle
     needs: clean-workdir
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.17' ]
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go }}
 
     - name: Validate
       run: make bundle
@@ -97,14 +109,17 @@ jobs:
     name: Build Bundle Image
     needs: validate-bundle
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.17' ]
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go }}
 
     - name: Build
       run: make bundle-build


### PR DESCRIPTION
- Update some actions from v2 to v3
- Enable testing with Go 1.16 and 1.17
- Update golangci-lint version to 1.45.2
- Update kube-lint version to 1.4.2

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>