### PR TITLE
Add watch permissions to mirrorpeer controller

### DIFF
--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -94,6 +94,7 @@ spec:
           - get
           - list
           - update
+          - watch
         - apiGroups:
           - authorization.k8s.io
           resources:
@@ -135,6 +136,7 @@ spec:
           - get
           - list
           - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -161,6 +163,7 @@ spec:
           - get
           - list
           - update
+          - watch
         - apiGroups:
           - multicluster.odf.openshift.io
           resources:
@@ -187,6 +190,16 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - ramendr.openshift.io
+          resources:
+          - drclusters
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - authorization.k8s.io
   resources:
@@ -75,6 +76,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -101,6 +103,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - multicluster.odf.openshift.io
   resources:
@@ -136,6 +139,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -63,10 +63,10 @@ const mirrorPeerFinalizer = "hub.mirrorpeer.multicluster.odf.openshift.io"
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=*
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons;clustermanagementaddons,verbs=*
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/status,verbs=*
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;create;update
-//+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;list;create;update
-//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;create;update
-//+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusters,verbs=get;list;create;update
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;create;update;watch
+//+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;list;create;update;watch
+//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;create;update;watch
+//+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusters,verbs=get;list;create;update;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
This commit will add watch permissions for deployment, services,
consoleplugin and DRCluster resources to the manager controller

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>