### PR TITLE
Adds bindings for spoke users on hub

### DIFF
--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -202,6 +202,19 @@ spec:
           - watch
         - apiGroups:
           - rbac.authorization.k8s.io
+          resourceNames:
+          - spoke-clusterrole-bindings
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
           - clusterroles

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -142,6 +142,19 @@ rules:
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io
+  resourceNames:
+  - spoke-clusterrole-bindings
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
   - clusterroles

--- a/controllers/utils/slice.go
+++ b/controllers/utils/slice.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	rbacv1 "k8s.io/api/rbac/v1"
 	"reflect"
 	"strings"
 
@@ -45,6 +46,15 @@ func RemoveString(slice []string, s string) (result []string) {
 		result = append(result, item)
 	}
 	return
+}
+
+func ContainsSubject(slice []rbacv1.Subject, subject *rbacv1.Subject) bool {
+	for i := range slice {
+		if reflect.DeepEqual(slice[i], *subject) {
+			return true
+		}
+	}
+	return false
 }
 
 // RemoveMirrorPeer removes the given mirrorPeer from the slice and returns the new slice


### PR DESCRIPTION
This commit adds changes that binds the hub's clusterrole to generated
spoke users.

This is done to fix a bug where the tokenagent on the spokeclusters are
unable to watch and make channges to mirrorpeer on the hub

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>