### PR TITLE
Bug 2087145: [release-4.10] Add bindings for spoke users on hub

### DIFF
--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -161,6 +161,19 @@ spec:
           - update
         - apiGroups:
           - rbac.authorization.k8s.io
+          resourceNames:
+          - spoke-clusterrole-bindings
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
           - clusterroles

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,6 +102,19 @@ rules:
   - update
 - apiGroups:
   - rbac.authorization.k8s.io
+  resourceNames:
+  - spoke-clusterrole-bindings
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
   - clusterroles

--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -18,16 +18,20 @@ package controllers
 
 import (
 	"context"
+	"reflect"
 
+	addons "github.com/red-hat-storage/odf-multicluster-orchestrator/addons/token-exchange"
 	tokenexchange "github.com/red-hat-storage/odf-multicluster-orchestrator/addons/token-exchange"
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/common"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"open-cluster-management.io/addon-framework/pkg/agent"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -45,6 +49,7 @@ type MirrorPeerReconciler struct {
 }
 
 const hubRecoveryLabel = "cluster.open-cluster-management.io/backup"
+const spokeClusterRoleBindingName = "spoke-clusterrole-bindings"
 
 //+kubebuilder:rbac:groups=multicluster.odf.openshift.io,resources=mirrorpeers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=multicluster.odf.openshift.io,resources=mirrorpeers/status,verbs=get;update;patch
@@ -59,6 +64,7 @@ const hubRecoveryLabel = "cluster.open-cluster-management.io/backup"
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=*
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons;clustermanagementaddons,verbs=*
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/status,verbs=*
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;create;update;delete;watch,resourceNames=spoke-clusterrole-bindings
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -130,6 +136,12 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			logger.Info("Successfully added label to mirrorpeer for disaster recovery", "MirrorPeer", mirrorPeerCopy.Name)
 			return ctrl.Result{Requeue: true}, nil
 		}
+	}
+
+	err = r.createClusterRoleBindingsForSpoke(ctx, mirrorPeer)
+	if err != nil {
+		logger.Error(err, "Failed to create cluster role bindings for spoke")
+		return ctrl.Result{}, err
 	}
 
 	if mirrorPeer.Status.Phase == "" {
@@ -342,4 +354,79 @@ func (r *MirrorPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multiclusterv1alpha1.MirrorPeer{}, builder.WithPredicates(mpPredicate)).
 		Complete(r)
+}
+
+func (r *MirrorPeerReconciler) createClusterRoleBindingsForSpoke(ctx context.Context, peer multiclusterv1alpha1.MirrorPeer) error {
+	crb := rbacv1.ClusterRoleBinding{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: spokeClusterRoleBindingName}, &crb)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+	}
+	var subjects []rbacv1.Subject
+	if crb.Subjects != nil {
+		subjects = crb.Subjects
+	}
+
+	// Add users and groups
+	for _, pr := range peer.Spec.Items {
+		usub := getSubjectByPeerRef(pr, "User")
+		gsub := getSubjectByPeerRef(pr, "Group")
+		if ContainsSubject(subjects, usub) {
+			subjects = append(subjects, *usub)
+		}
+
+		if ContainsSubject(subjects, gsub) {
+			subjects = append(subjects, *gsub)
+		}
+	}
+
+	spokeRoleBinding := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: spokeClusterRoleBindingName,
+		},
+		Subjects: subjects,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "open-cluster-management:token-exchange:agent",
+		},
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, &spokeRoleBinding, func() error {
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getSubjectByPeerRef(pr multiclusterv1alpha1.PeerRef, kind string) *rbacv1.Subject {
+	switch kind {
+	case "User":
+		return &rbacv1.Subject{
+			Kind:     kind,
+			Name:     agent.DefaultUser(pr.ClusterName, addons.TokenExchangeName, addons.TokenExchangeName),
+			APIGroup: "rbac.authorization.k8s.io",
+		}
+	case "Group":
+		return &rbacv1.Subject{
+			Kind:     kind,
+			Name:     agent.DefaultGroups(pr.ClusterName, addons.TokenExchangeName)[0],
+			APIGroup: "rbac.authorization.k8s.io",
+		}
+	default:
+		return nil
+	}
+}
+
+func ContainsSubject(slice []rbacv1.Subject, subject *rbacv1.Subject) bool {
+	for i := range slice {
+		if reflect.DeepEqual(slice[i], *subject) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This commit adds changes that binds the hub's clusterrole to generated
spoke users.

This is done to fix a bug where the tokenagent on the spokeclusters are
unable to watch and make channges to mirrorpeer on the hub

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>