### PR TITLE
Fix webhook connection refused error

### DIFF
--- a/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -4,8 +4,6 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  labels:
-    control-plane: odfmo-controller-manager
   name: mirrorpeers.multicluster.odf.openshift.io
 spec:
   group: multicluster.odf.openshift.io

--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -8,9 +8,6 @@ metadata:
           "apiVersion": "multicluster.odf.openshift.io/v1alpha1",
           "kind": "MirrorPeer",
           "metadata": {
-            "labels": {
-              "control-plane": "odfmo-controller-manager"
-            },
             "name": "mirrorpeer-sample"
           },
           "spec": {
@@ -42,8 +39,6 @@ metadata:
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  labels:
-    control-plane: odfmo-controller-manager
   name: odf-multicluster-orchestrator.v0.0.1
   namespace: placeholder
 spec:
@@ -295,13 +290,11 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/name: odf-multicluster-console
-              control-plane: odfmo-controller-manager
           strategy: {}
           template:
             metadata:
               labels:
                 app.kubernetes.io/name: odf-multicluster-console
-                control-plane: odfmo-controller-manager
             spec:
               containers:
               - image: quay.io/ocs-dev/odf-multicluster-console:latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,3 +14,7 @@ images:
 - name: controller
   newName: quay.io/ocs-dev/odf-multicluster-orchestrator
   newTag: latest
+
+#Labels to add to all resources and selectors.
+commonLabels:
+  control-plane: odfmo-controller-manager

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -26,6 +26,3 @@ patchesJson6902:
     # Update the indices in this path if adding or removing volumes in the manager's Deployment.
     - op: remove
       path: /spec/template/spec/volumes/0
- #Labels to add to all resources and selectors.
-commonLabels:
- control-plane: odfmo-controller-manager

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -4,3 +4,7 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+#Labels to add to all resources and selectors.
+commonLabels:
+  control-plane: odfmo-controller-manager


### PR DESCRIPTION
This commit makes changes to kustomization files that will only add the
label `control-plane: odfmo-controller-manager` to manager and webhooks.

This will fix the webhook issues where the service was targeting
multicluster-console server and failing

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>