### PR TITLE
Sync mode fixes and status updates

### DIFF
--- a/addons/token-exchange/agent_mirrorpeer_controller.go
+++ b/addons/token-exchange/agent_mirrorpeer_controller.go
@@ -130,15 +130,13 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	clusterFSIDs := make(map[string]string)
-	klog.Infof("Fetching clusterFSIDs")
-	err = r.fetchClusterFSIDs(ctx, &mirrorPeer, clusterFSIDs)
-	if err != nil {
-		return ctrl.Result{Requeue: true}, fmt.Errorf("failed to get all cluster FSIDs, retrying again: %v", err)
-	}
-
-	klog.Info(clusterFSIDs)
 	if mirrorPeer.Spec.Type == multiclusterv1alpha1.Async {
+		clusterFSIDs := make(map[string]string)
+		klog.Infof("Fetching clusterFSIDs")
+		err = r.fetchClusterFSIDs(ctx, &mirrorPeer, clusterFSIDs)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, fmt.Errorf("failed to get all cluster FSIDs, retrying again: %v", err)
+		}
 		klog.Infof("enabling async mode dependencies")
 		err = r.enableCSIAddons(ctx, scr.Namespace)
 		if err != nil {
@@ -154,12 +152,12 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if len(errs) > 0 {
 			return ctrl.Result{}, fmt.Errorf("few failures occured while creating VolumeReplicationClasses: %v", errs)
 		}
-	}
 
-	klog.Infof("labeling rbd storageclasses")
-	errs := r.labelRBDStorageClasses(ctx, mirrorPeer, scr.Namespace, clusterFSIDs)
-	if len(errs) > 0 {
-		return ctrl.Result{}, fmt.Errorf("few failures occured while labeling RBD StorageClasses: %v", errs)
+		klog.Infof("labeling rbd storageclasses")
+		errs = r.labelRBDStorageClasses(ctx, mirrorPeer, scr.Namespace, clusterFSIDs)
+		if len(errs) > 0 {
+			return ctrl.Result{}, fmt.Errorf("few failures occured while labeling RBD StorageClasses: %v", errs)
+		}
 	}
 
 	klog.Infof("creating s3 buckets")

--- a/api/v1alpha1/mirrorpeer_types.go
+++ b/api/v1alpha1/mirrorpeer_types.go
@@ -26,6 +26,8 @@ type DRType string
 const (
 	ExchangingSecret PhaseType = "ExchangingSecret"
 	ExchangedSecret  PhaseType = "ExchangedSecret"
+	S3ProfileSynced  PhaseType = "S3ProfileSynced"
+	S3ProfileSyncing PhaseType = "S3ProfileSyncing"
 	Deleting         PhaseType = "Deleting"
 	Sync             DRType    = "sync"
 	Async            DRType    = "async"


### PR DESCRIPTION
This commit fixes a bug where the DRCluster objects are not created
properly for MetroDR due to absence of secrets for external mode.

As a temporary workaround, the region for the DRCluster will be empty in case of sync mode and needs to be updated by user.
This workaround needs to be there till external mode clusters are
supported throughout MCO.

The MirrorPeer phase has two new phases for sync mode, S3ProfileSynced
and S3ProfileSyncing.

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>