### PR TITLE
Set goflags to empty when using go install

### DIFF
--- a/hack/make/tools.mk
+++ b/hack/make/tools.mk
@@ -6,7 +6,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin GOFLAGS='' go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
The GOFLAGS is set to -mod=vendor when running on Openshift CI
Unsetting this flag is necessary for go install to work properly.

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>