### PR TITLE
Set default filter string

### DIFF
--- a/addons/token-exchange/rook_secret_handler.go
+++ b/addons/token-exchange/rook_secret_handler.go
@@ -39,8 +39,13 @@ const (
 
 func (rookSecretHandler) getBlueSecretFilter(obj interface{}) (ClusterType, bool) {
 	blueSecretMatchString := os.Getenv("TOKEN_EXCHANGE_SOURCE_SECRET_STRING_MATCH")
+
+	if blueSecretMatchString == "" {
+		blueSecretMatchString = RookDefaultBlueSecretMatchConvergedString
+	}
+
 	if s, ok := obj.(*corev1.Secret); ok {
-		if s.Type == RookType && (strings.Contains(s.ObjectMeta.Name, blueSecretMatchString) || strings.Contains(s.ObjectMeta.Name, RookDefaultBlueSecretMatchConvergedString)) {
+		if s.Type == RookType && strings.Contains(s.ObjectMeta.Name, blueSecretMatchString) {
 			return CONVERGED, true
 		}
 


### PR DESCRIPTION
The current filter when fetched from env is empty and matches for every secret created. To avoid this, we set the filter to a default string.

`I0912 07:34:38.614299       1 blue_secret_controller.go:76] reconciling addon deploy "openshift-storage/rook-ceph-mds-ocs-storagecluster-cephfilesystem-b-keyring"
E0912 07:34:38.614438       1 base_controller.go:270] "managedcluster-secret-tokenexchange-controller" controller failed to sync "openshift-storage/rook-ceph-mds-ocs-storagecluster-cephfilesystem-b-keyring", err: failed to get the storage cluster name from the secret "rook-ceph-mds-ocs-storagecluster-cephfilesystem-b-keyring" in namespace "openshift-storage" in managed cluster. Error could not get storageCluster name`

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>