### PR TITLE
Fix issues with secret exchange

### DIFF
--- a/addons/token-exchange/blue_secret_controller.go
+++ b/addons/token-exchange/blue_secret_controller.go
@@ -59,7 +59,7 @@ func newblueSecretTokenExchangeAgentController(
 	eventFilterFn := func(obj interface{}) bool {
 		isMatched := false
 		for _, handler := range secretExchangeHandler.RegisteredHandlers {
-			_, isMatched = handler.getBlueSecretFilter(obj)
+			isMatched = handler.getBlueSecretFilter(obj)
 		}
 		return isMatched
 	}

--- a/addons/token-exchange/blue_secret_controller_test.go
+++ b/addons/token-exchange/blue_secret_controller_test.go
@@ -35,12 +35,11 @@ type testCase struct {
 	syncExpected  bool
 }
 
-func (fakeSecretHandler) getBlueSecretFilter(obj interface{}) (ClusterType, bool) {
-	defaultClusterType := CONVERGED
+func (fakeSecretHandler) getBlueSecretFilter(obj interface{}) bool {
 	if metaObj, has := obj.(metav1.Object); has {
-		return defaultClusterType, metaObj.GetName() == "sourcesecret"
+		return metaObj.GetName() == "sourcesecret"
 	}
-	return defaultClusterType, false
+	return false
 }
 
 func (f fakeSecretHandler) syncBlueSecret(name string, namespace string, c *blueSecretTokenExchangeAgentController) error {
@@ -49,7 +48,7 @@ func (f fakeSecretHandler) syncBlueSecret(name string, namespace string, c *blue
 	if err != nil {
 		return err
 	}
-	if _, ok := f.getBlueSecretFilter(secret); !ok {
+	if ok := f.getBlueSecretFilter(secret); !ok {
 		return fmt.Errorf("not blue secret")
 	}
 	return nil

--- a/addons/token-exchange/rook_secret_handler_test.go
+++ b/addons/token-exchange/rook_secret_handler_test.go
@@ -248,7 +248,7 @@ func getExpectedRookBlueSecret(t *testing.T) *corev1.Secret {
 	data[utils.NamespaceKey] = []byte(TestStorageClusterNamespace)
 	data[utils.StorageClusterNameKey] = []byte(TestStorageClusterName)
 	data[utils.SecretOriginKey] = []byte(utils.OriginMap["RookOrigin"])
-	data[utils.ClusterType] = []byte(CONVERGED)
+	data[utils.ClusterTypeKey] = []byte(utils.CONVERGED)
 
 	expectedSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/addons/token-exchange/secret_exchange_handler_interface.go
+++ b/addons/token-exchange/secret_exchange_handler_interface.go
@@ -2,7 +2,7 @@ package addons
 
 // common func between different secret handlers
 type SecretExchangeHandlerInterface interface {
-	getBlueSecretFilter(interface{}) (ClusterType, bool)
+	getBlueSecretFilter(interface{}) bool
 	getGreenSecretFilter(interface{}) bool
 	syncBlueSecret(string, string, *blueSecretTokenExchangeAgentController) error
 	syncGreenSecret(string, string, *greenSecretTokenExchangeAgentController) error

--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -467,7 +467,12 @@ func (r *MirrorPeerReconciler) createDRClusters(ctx context.Context, mp *multicl
 				logger.Error(err, "Failed to fetch rook secret", "Secret", rookSecretName)
 				return err
 			}
-			fsid = string(hs.Data[utils.FSID])
+			rt, err := utils.UnmarshalRookSecretExternal(hs)
+			if err != nil {
+				logger.Error(err, "Failed to unmarshal rook secret", "Secret", rookSecretName)
+				return err
+			}
+			fsid = rt.FSID
 		} else {
 			hs, err := utils.FetchSecretWithName(ctx, r.Client, types.NamespacedName{Name: rookSecretName, Namespace: clusterName})
 			if err != nil {

--- a/controllers/utils/cluster.go
+++ b/controllers/utils/cluster.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"context"
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ClusterType string
+
+const (
+	CONVERGED ClusterType = "Converged"
+	EXTERNAL  ClusterType = "External"
+	UNKNOWN   ClusterType = "Unknown"
+)
+
+func GetClusterType(storageClusterName string, namespace string, client client.Client) (ClusterType, error) {
+	var storageCluster ocsv1.StorageCluster
+	err := client.Get(context.TODO(), types.NamespacedName{Name: storageClusterName, Namespace: namespace}, &storageCluster)
+	if err != nil {
+		return UNKNOWN, err
+	}
+	if storageCluster.Spec.ExternalStorage.Enable {
+		return EXTERNAL, nil
+	}
+	return CONVERGED, nil
+}

--- a/controllers/utils/secret.go
+++ b/controllers/utils/secret.go
@@ -29,7 +29,7 @@ const (
 	SecretOriginKey                       = "secret-origin"
 	MirrorPeerSecret                      = "mirrorpeersecret"
 	RookTokenKey                          = "token"
-	ClusterType                           = "cluster_type"
+	ClusterTypeKey                        = "cluster_type"
 )
 
 type RookToken struct {
@@ -38,6 +38,13 @@ type RookToken struct {
 	MonHost   string `json:"mon_host"`
 	ClientId  string `json:"client_id"`
 	Key       string `json:"key"`
+}
+
+type RookTokenExternal struct {
+	CephSecret   string `json:"ceph-secret,omitempty"`
+	CephUsername string `json:"ceph-username,omitempty"`
+	FSID         string `json:"fsid"`
+	MonSecret    string `json:"mon-secret,omitempty"`
 }
 
 type HubToken struct {
@@ -268,6 +275,25 @@ func UnmarshalRookSecret(rookSecret *corev1.Secret) (*RookToken, error) {
 	err = json.Unmarshal(encodedData, &token)
 	if err != nil {
 		return nil, err
+	}
+
+	return &token, nil
+}
+
+func UnmarshalRookSecretExternal(rookSecret *corev1.Secret) (*RookTokenExternal, error) {
+	fsid := string(rookSecret.Data["fsid"])
+
+	cephUsername := string(rookSecret.Data["ceph-username"])
+
+	cephSecret := string(rookSecret.Data["ceph-secret"])
+
+	monSecret := string(rookSecret.Data["mon-secret"])
+
+	token := RookTokenExternal{
+		FSID:         string(fsid),
+		CephSecret:   string(cephSecret),
+		CephUsername: string(cephUsername),
+		MonSecret:    string(monSecret),
 	}
 
 	return &token, nil


### PR DESCRIPTION
This commit fixes the following issues -
1. Fixes issue with detecting multiple secrets and syncing wrong secrets
2. Fixes issue with properly detecting whether a cluster is in external mode or converged mode.
3. Small fixes related to unmarshalling of external rook secret
4. Add unit tests for unmarshallling
5. Fixes issue with DRCluster not using the correct fsid key to get from secret.
6. Fixes tests to accommodate the above fixes
7. Fixes labelling of storageclasses with fsid, requeues the requests after 60 seconds to avoid barrage of errors in the logs

Tested for Async mode.
MirrorPeer is in exchanged phase after 5-7 mins 

![Screenshot from 2022-09-21 19-57-16](https://user-images.githubusercontent.com/57935785/191533358-17ba7c44-ab57-4581-bcda-5be622cc9b64.png)

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>