### PR TITLE
Bug 2126008: Fix token-exchange and functionality enhancements

### DIFF
--- a/addons/token-exchange/token_exchanger_agent.go
+++ b/addons/token-exchange/token_exchanger_agent.go
@@ -58,7 +58,7 @@ func (o *AgentOptions) RunAgent(ctx context.Context, controllerContext *controll
 	if err != nil {
 		return err
 	}
-	spokeKubeInformerFactory := informers.NewSharedInformerFactoryWithOptions(spokeKubeClient, 10*time.Minute)
+	spokeKubeInformerFactory := informers.NewSharedInformerFactoryWithOptions(spokeKubeClient, 2*time.Minute)
 
 	hubRestConfig, err := clientcmd.BuildConfigFromFlags("" /* leave masterurl as empty */, o.HubKubeconfigFile)
 	if err != nil {
@@ -68,7 +68,7 @@ func (o *AgentOptions) RunAgent(ctx context.Context, controllerContext *controll
 	if err != nil {
 		return err
 	}
-	hubKubeInformerFactory := informers.NewSharedInformerFactoryWithOptions(hubKubeClient, 10*time.Minute, informers.WithNamespace(o.SpokeClusterName))
+	hubKubeInformerFactory := informers.NewSharedInformerFactoryWithOptions(hubKubeClient, 2*time.Minute, informers.WithNamespace(o.SpokeClusterName))
 	err = registerHandler(multiclusterv1alpha1.DRType(o.DRMode), controllerContext.KubeConfig, hubRestConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
The commit does the following changes -
- From 4.12 onwards, Volume replication CSI addon is enabled by default on all odf
clusters. We do not need to enable on and off through the operator.
- Adding additional logs and cleaning the error logs when the secrets
 are not found. Instead just doing an info log and requeing the key
till the secrets are available
- Shuffling few of the operations in agent controller for creating s3
  buckets and delaying operations that require secret exchange.
- SharedInformer will resync duration of 2 mins instead of 10 min. This
will allow fast detection of secrets and the help with hastening the
operations

![Screenshot from 2022-09-29 18-51-53](https://user-images.githubusercontent.com/57935785/193046780-353b31b2-bfc6-469e-9013-8c6541b34bd8.png)

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>