### PR TITLE
Fix tokenexchange flow for external cluster

### DIFF
--- a/addons/token-exchange/agent_mirrorpeer_controller.go
+++ b/addons/token-exchange/agent_mirrorpeer_controller.go
@@ -21,6 +21,10 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/replication.storage/v1alpha1"
 	obv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
@@ -38,9 +42,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sort"
-	"strconv"
-	"time"
 )
 
 // MirrorPeerReconciler reconciles a MirrorPeer object

--- a/addons/token-exchange/secret_exchange_handler_utils.go
+++ b/addons/token-exchange/secret_exchange_handler_utils.go
@@ -72,7 +72,7 @@ func generateBlueSecret(secret *corev1.Secret, secretType utils.SecretLabelType,
 	return &nSecret, nil
 }
 
-func generateBlueSecretForExternal(rookCephMon *corev1.Secret, labelType utils.SecretLabelType, name string, managedClusterName string, customData map[string][]byte) (*corev1.Secret, error) {
+func generateBlueSecretForExternal(rookCephMon *corev1.Secret, labelType utils.SecretLabelType, name string, sc string, managedClusterName string, customData map[string][]byte) (*corev1.Secret, error) {
 	if rookCephMon == nil {
 		return nil, fmt.Errorf("Failed to create secret on the hub, secret is nil")
 	}
@@ -83,6 +83,8 @@ func generateBlueSecretForExternal(rookCephMon *corev1.Secret, labelType utils.S
 	}
 
 	data := make(map[string][]byte)
+	data[utils.NamespaceKey] = []byte(rookCephMon.Namespace)
+	data[utils.StorageClusterNameKey] = []byte(sc)
 	for key, value := range customData {
 		data[key] = value
 	}

--- a/controllers/utils/s3.go
+++ b/controllers/utils/s3.go
@@ -26,7 +26,6 @@ const (
 	RookSecretHandlerName = "rook"
 	S3SecretHandlerName   = "s3"
 	DRModeAnnotationKey   = "multicluster.openshift.io/mode"
-	FSID                  = "FSID"
 )
 
 func GetCurrentStorageClusterRef(mp *multiclusterv1alpha1.MirrorPeer, spokeClusterName string) (*multiclusterv1alpha1.StorageClusterRef, error) {


### PR DESCRIPTION
Removed secret type check for rook-ceph-mon and cluster-peer-token

Signed-off-by: Gowtham Shanmugasundaram <gshanmug@redhat.com>