### PR TITLE
fix skipRange update to CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,15 +103,15 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd config/console && $(KUSTOMIZE) edit set image odf-multicluster-console=$(MULTICLUSTER_CONSOLE_IMG)
 ifeq ($(FUSION) , true)
-	export IMG=$(IMG) MULTICLUSTER_CONSOLE_IMG=$(MULTICLUSTER_CONSOLE_IMG) && $(KUSTOMIZE) build config/fusion | envsubst | $(OSDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	cd config/fusion/bases && $(KUSTOMIZE) edit add annotation --force 'olm.skipRange':"$(SKIP_RANGE)" && \
 		$(KUSTOMIZE) edit add patch --name odf-multicluster-orchestrator.v0.0.0 --kind ClusterServiceVersion \
 		--patch '[{"op": "replace", "path": "/spec/replaces", "value": "$(REPLACES)"}]'
+	export IMG=$(IMG) MULTICLUSTER_CONSOLE_IMG=$(MULTICLUSTER_CONSOLE_IMG) && $(KUSTOMIZE) build config/fusion | envsubst | $(OSDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 else
-	export IMG=$(IMG) MULTICLUSTER_CONSOLE_IMG=$(MULTICLUSTER_CONSOLE_IMG) && $(KUSTOMIZE) build config/manifests | envsubst | $(OSDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	cd config/manifests/bases && $(KUSTOMIZE) edit add annotation --force 'olm.skipRange':"$(SKIP_RANGE)" && \
 		$(KUSTOMIZE) edit add patch --name odf-multicluster-orchestrator.v0.0.0 --kind ClusterServiceVersion \
 		--patch '[{"op": "replace", "path": "/spec/replaces", "value": "$(REPLACES)"}]'
+	export IMG=$(IMG) MULTICLUSTER_CONSOLE_IMG=$(MULTICLUSTER_CONSOLE_IMG) && $(KUSTOMIZE) build config/manifests | envsubst | $(OSDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 endif
 	$(OSDK) bundle validate ./bundle
 


### PR DESCRIPTION
We were updating SkipRange annotation after the bundle was generated. So, CSV does not have SkipRange annotation which then blocks upgrades.

This issue is difficult to catch as it only happens on the first run of bundle generation. Subsequent bundle generation gets the annotation correctly.