### PR TITLE
add labels for supported arch

### DIFF
--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -40,6 +40,10 @@ metadata:
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: odf-multicluster-orchestrator.v0.0.1
   namespace: placeholder
 spec:

--- a/config/manifests/bases/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/config/manifests/bases/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -6,6 +6,10 @@ metadata:
     capabilities: Basic Install
     console.openshift.io/plugins: '["odf-multicluster-console"]'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: odf-multicluster-orchestrator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
These labels are used by operator-framework to determine archs supported by the operator.