### PR TITLE
Bug 2183198: [release-4.12] Disables leader election for addons

### DIFF
--- a/addons/token-exchange/token_exchanger_agent.go
+++ b/addons/token-exchange/token_exchanger_agent.go
@@ -25,13 +25,18 @@ const (
 
 func NewAgentCommand() *cobra.Command {
 	o := NewAgentOptions()
-	cmd := controllercmd.
-		NewControllerCommandConfig(TokenExchangeName, version.Info{Major: "0", Minor: "1"}, o.RunAgent).
-		NewCommand()
+	cmdConfig := controllercmd.
+		NewControllerCommandConfig(TokenExchangeName, version.Info{Major: "0", Minor: "1"}, o.RunAgent)
+
+	cmd := cmdConfig.NewCommand()
 	cmd.Use = TokenExchangeName
 	cmd.Short = "Start the token exchange addon agent"
 
 	o.AddFlags(cmd)
+
+	flags := cmd.Flags()
+	flags.BoolVar(&cmdConfig.DisableLeaderElection, "disable-leader-election", true, "Disable leader election for the agent")
+
 	return cmd
 }
 


### PR DESCRIPTION
This commit fixes an with addon leader election. The leader election gets stuck on acquiring lock for the namespace lease. This fix disables the leader election process for addons as it is not required for a single replica deployments.

Main branch PR: https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/152