### PR TITLE
enable multiclusterservice on storagecluster

### DIFF
--- a/api/v1alpha1/mirrorpeer_types.go
+++ b/api/v1alpha1/mirrorpeer_types.go
@@ -69,6 +69,14 @@ type MirrorPeerSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	ManageS3 bool `json:"manageS3,omitempty"`
+
+	// OverlappingCIDR should be set to true if the peer clusters
+	// have overlapping Pod or Service CIDR. This will enable storage
+	// clusters to use submariner globalnet. Enabling this will cause
+	// storage service disruption while network is being reconfigured.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	OverlappingCIDR bool `json:"overlappingCIDR,omitempty"`
 }
 
 // MirrorPeerStatus defines the observed state of MirrorPeer

--- a/api/v1alpha1/mirrorpeer_webhook.go
+++ b/api/v1alpha1/mirrorpeer_webhook.go
@@ -92,6 +92,10 @@ func (r *MirrorPeer) ValidateUpdate(old runtime.Object) error {
 			return fmt.Errorf("error validating update: new MirrorPeer %s references a StorageCluster %s/%s that is not in the old MirrorPeer", r.ObjectMeta.Name, pr.StorageClusterRef.Namespace, pr.StorageClusterRef.Name)
 		}
 	}
+
+	if oldMirrorPeer.Spec.OverlappingCIDR && !r.Spec.OverlappingCIDR {
+		return fmt.Errorf("error updating MirrorPeer: OverlappingCIDR value can not be changed from %t to %t. This is to prevent Disaster Recovery from being unusable between clusters that have overlapping IPs", oldMirrorPeer.Spec.OverlappingCIDR, r.Spec.OverlappingCIDR)
+	}
 	return validateMirrorPeer(r)
 }
 

--- a/config/crd/bases/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/config/crd/bases/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -66,6 +66,13 @@ spec:
               manageS3:
                 default: false
                 type: boolean
+              overlappingCIDR:
+                default: false
+                description: OverlappingCIDR should be set to true if the peer clusters
+                  have overlapping Pod or Service CIDR. This will enable storage clusters
+                  to use submariner globalnet. Enabling this will cause storage service
+                  disruption while network is being reconfigured.
+                type: boolean
               schedulingIntervals:
                 description: 'SchedulingIntervals is a list of intervals at which
                   mirroring snapshots are taken. DEPRECATED :  Any changes to this

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,11 @@ require (
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/library-go v0.0.0-20230127195720-edf819b079cf
 	github.com/ramendr/ramen v0.0.0-20230417210457-6d88803e39ed
-	github.com/red-hat-storage/ocs-operator v0.0.1-master.0.20230401010509-91dfd1590040
-	github.com/rook/rook v1.11.2
+	github.com/red-hat-storage/ocs-operator v0.0.1-master.0.20230417124524-f67100d2dde1
+	github.com/rook/rook v1.11.4
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
+	github.com/submariner-io/submariner-operator v0.14.3
 	golang.org/x/sync v0.1.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
@@ -36,7 +37,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
-	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534 // indirect
 	github.com/coreos/pkg v0.0.0-20230327231512-ba87abf18a23 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
@@ -111,6 +112,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/stolostron/multicloud-operators-placementrule v1.2.4-1-20220311-8eedb3f.0.20220411162042-3de0a2f908f1 // indirect
+	github.com/submariner-io/admiral v0.14.3 // indirect
+	github.com/submariner-io/submariner v0.14.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.5 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.5 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
-github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.25.37/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.41/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -454,8 +454,9 @@ github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pq
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
-github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534 h1:rtAn27wIbmOGUs7RIbVgPEjb31ehTVniDwPGXyMxm5U=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -708,8 +709,8 @@ github.com/go-openapi/spec v0.19.8/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHK
 github.com/go-openapi/spec v0.19.15/go.mod h1:+81FIL1JwC5P3/Iuuozq3pPE9dXdIEGxFutcFKaVbmU=
 github.com/go-openapi/spec v0.20.0/go.mod h1:+81FIL1JwC5P3/Iuuozq3pPE9dXdIEGxFutcFKaVbmU=
 github.com/go-openapi/spec v0.20.1/go.mod h1:93x7oh+d+FQsmsieroS4cmR3u0p/ywH649a3qwC9OsQ=
-github.com/go-openapi/spec v0.20.3 h1:uH9RQ6vdyPSs2pSy9fL8QPspDF2AMIMPtmK5coSSjtQ=
 github.com/go-openapi/spec v0.20.3/go.mod h1:gG4F8wdEDN+YPBMVnzE85Rbhf+Th2DTvA9nFPQ5AYEg=
+github.com/go-openapi/spec v0.20.4 h1:O8hJrt0UMnhHcluhIdUgCLRWyM2x7QkBXRvOs7m+O1M=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.19.0/go.mod h1:+uW+93UVvGGq2qGaZxdDeJqSAqBqBdl+ZPMF/cC8nDY=
@@ -1724,8 +1725,8 @@ github.com/ramendr/ramen v0.0.0-20230417210457-6d88803e39ed h1:ObBRxKNm/JuomVIol
 github.com/ramendr/ramen v0.0.0-20230417210457-6d88803e39ed/go.mod h1:RsMwY3GE3v945wmm9RT99X1FwKLwXR4APWgEU2av9Q4=
 github.com/rboyer/safeio v0.2.1 h1:05xhhdRNAdS3apYm7JRjOqngf4xruaW959jmRxGDuSU=
 github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy7Fmig=
-github.com/red-hat-storage/ocs-operator v0.0.1-master.0.20230401010509-91dfd1590040 h1:o4OCQh5FIBJ0Y35IdbwFaFIfxDkbT+TG9M1y7IIRO8g=
-github.com/red-hat-storage/ocs-operator v0.0.1-master.0.20230401010509-91dfd1590040/go.mod h1:UZEcKVIMhNuoF09Jpr5eAVTv5Ko92tIERKb/DYCAQJ4=
+github.com/red-hat-storage/ocs-operator v0.0.1-master.0.20230417124524-f67100d2dde1 h1:NsDk/2TDFhmDGoQbntsdvfsAMsqBZDzXhpazHLQRptk=
+github.com/red-hat-storage/ocs-operator v0.0.1-master.0.20230417124524-f67100d2dde1/go.mod h1:+m+BfgWXPG0ZnH5YaAX5kWcH4fK2SbNJMKBgj0RRYeE=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOekn6B5G/+GMtks9UKbvRU/CMM/o=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
@@ -1741,8 +1742,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/rook/rook v1.11.2 h1:owLH5CNtsrgz/XsxQACuG1ldNmA36lI2Vz2m+ZQ654w=
-github.com/rook/rook v1.11.2/go.mod h1:MPltNTZtf8DmhJjAxsdgYmJaJmFcq/CHadTm2DMPPiM=
+github.com/rook/rook v1.11.4 h1:V5+r8JnVpSCdWGZ8eV5zUX1SnMTgCnz3azux+7Jefzc=
+github.com/rook/rook v1.11.4/go.mod h1:RwQdIZvb7BGomy9yR9caWYCoT8pHngYsxBXg6Fl8LZk=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.4.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
@@ -1848,6 +1849,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/submariner-io/admiral v0.14.3 h1:bsiqjcvDBjTDS6bGiqpcosAtqQExT0E7fClQgyuqWnA=
+github.com/submariner-io/admiral v0.14.3/go.mod h1:T1kc23dp3MxFWuuZTm1xAr7PAsqRtyaq73asC3oELmQ=
+github.com/submariner-io/submariner v0.14.3 h1:3RDakyqXzeCiAM+GDnuCyfyNuTIpNAN6LlmsCoTNowE=
+github.com/submariner-io/submariner v0.14.3/go.mod h1:gVj2sZlxDUTC1VV2zdbyFPwJr/MpmXfO5Ca/a/eMbHo=
+github.com/submariner-io/submariner-operator v0.14.3 h1:UOndZonc0i5RLrWV/KAQnk0DosVUxbvbOrk1gpxE3eE=
+github.com/submariner-io/submariner-operator v0.14.3/go.mod h1:6OtibmEyCOUCyKFaK/6lrhKPX8pL/iX5yoA3PVRI/4w=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=


### PR DESCRIPTION
When requested, enable multiclusterservice on StorageCluster in all the ManagedClusters referenced by MirrorPeer.

```
spec:
  ...
  overlappingCIDR: true
```