### PR TITLE
Fixes for MMode reconciler

### DIFF
--- a/addons/maintainence-agent/maintenance_mode_controller.go
+++ b/addons/maintainence-agent/maintenance_mode_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	ramenv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/utils"
 	rookv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"time"
 )
 
 type MaintenanceModeReconciler struct {
@@ -54,66 +54,74 @@ func (r *MaintenanceModeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	if mmode.GetDeletionTimestamp().IsZero() {
-		if !utils.ContainsString(mmode.GetFinalizers(), MaintenanceModeFinalizer) {
-			klog.Info("finalizer not found on MaintenanceMode. adding Finalizer ", MaintenanceModeFinalizer)
-			mmode.Finalizers = append(mmode.Finalizers, MaintenanceModeFinalizer)
-			if err := r.SpokeClient.Update(ctx, &mmode); err != nil {
-				klog.Error(err, "failed to add finalizer to MaintenanceMode", mmode.Name)
-				return ctrl.Result{}, err
-			}
-		}
-	}
-
-	cephClusters, err := fetchAllCephClusters(ctx, r.SpokeClient)
+	cephClusters, err := utils.FetchAllCephClusters(ctx, r.SpokeClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	if cephClusters == nil || len(cephClusters.Items) == 0 {
 		klog.Info("no CephClusters available on the cluster")
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
-	actionableCephClusters := filterCephClustersByStorageId(cephClusters, mmode.Spec.TargetID, mmode.Spec.StorageProvisioner)
+	actionableCephCluster := filterCephClustersByStorageIdOrReplicationId(cephClusters, mmode.Spec.TargetID, mmode.Spec.StorageProvisioner)
 
-	if len(actionableCephClusters) == 0 {
-		klog.Info("no CephClusters present with required parameters for maintenance", "StorageId", mmode.Spec.TargetID, "Provisioner", mmode.Spec.StorageProvisioner)
-		return ctrl.Result{}, nil
+	if actionableCephCluster == nil {
+		klog.Infof("no CephCluster present with required parameters for maintenance. StorageId/ReplicationId=%s , Provisioner=%s ", mmode.Spec.TargetID, mmode.Spec.StorageProvisioner)
+		// Requeueing the request as the cephcluster can be potentially found if it is labeled later.
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	if !mmode.GetDeletionTimestamp().IsZero() || len(mmode.Spec.Modes) == 0 {
-		result, err := r.startMaintenanceActions(ctx, mmode, actionableCephClusters, false)
+		if !utils.ContainsString(mmode.GetFinalizers(), MaintenanceModeFinalizer) {
+			return ctrl.Result{}, nil
+		}
+		result, err := r.startMaintenanceActions(ctx, mmode, actionableCephCluster, false)
 		if err != nil {
 			return result, err
 		}
-		mmode.Finalizers = utils.RemoveString(mmode.Finalizers, MaintenanceModeFinalizer)
-
-		if err := r.SpokeClient.Update(ctx, &mmode); err != nil {
-			klog.Error(err, "failed to remove finalizer from MaintenanceMode ", err)
+		latestMMode, fetchErr := r.fetchLatestVersionMMode(ctx, mmode.Name)
+		if fetchErr != nil {
+			return ctrl.Result{}, fetchErr
+		}
+		latestMMode.Finalizers = utils.RemoveString(latestMMode.Finalizers, MaintenanceModeFinalizer)
+		err = r.SpokeClient.Update(ctx, &mmode)
+		if err != nil {
+			klog.Error("failed to remove finalizer from MaintenanceMode ")
 			return ctrl.Result{}, err
 		}
-		klog.Info("MaintenanceMode deleted, skipping reconciliation")
+		klog.Info("MaintenanceMode disabled")
 		return ctrl.Result{}, nil
-	} else {
-		_, err := r.startMaintenanceActions(ctx, mmode, actionableCephClusters, true)
-		if err != nil {
+	}
+
+	if !utils.ContainsString(mmode.GetFinalizers(), MaintenanceModeFinalizer) {
+		klog.Infof("finalizer not found on MaintenanceMode. adding Finalizer=%s", MaintenanceModeFinalizer)
+		mmode.Finalizers = append(mmode.Finalizers, MaintenanceModeFinalizer)
+		if err := r.SpokeClient.Update(ctx, &mmode); err != nil {
+			klog.Errorf("failed to add finalizer to MaintenanceMode=%s. err=%v ", mmode.Name, err)
 			return ctrl.Result{}, err
 		}
 	}
 
-	return ctrl.Result{}, nil
+	if mmode.Status.State == ramenv1alpha1.MModeStateCompleted && mmode.Status.ObservedGeneration == mmode.Generation {
+		return ctrl.Result{}, nil
+	}
+
+	_, err = r.startMaintenanceActions(ctx, mmode, actionableCephCluster, true)
+	statusErr := r.SpokeClient.Status().Update(ctx, &mmode)
+	if statusErr != nil {
+		klog.Infof("failed to update status of maintenancemode=%s", mmode.Name)
+		return ctrl.Result{}, statusErr
+	}
+	return ctrl.Result{}, err
 }
 
-func (r *MaintenanceModeReconciler) startMaintenanceActions(ctx context.Context, mmode ramenv1alpha1.MaintenanceMode, clusters []rookv1.CephCluster, scaleDown bool) (ctrl.Result, error) {
-	klog.Info("starting actions on MaintenanceMode", "MaintenanceMode ", mmode.Name)
+func (r *MaintenanceModeReconciler) startMaintenanceActions(ctx context.Context, mmode ramenv1alpha1.MaintenanceMode, cluster *rookv1.CephCluster, scaleDown bool) (ctrl.Result, error) {
+	klog.Infof("starting actions on MaintenanceMode %q", mmode.Name)
 	for _, mode := range mmode.Spec.Modes {
-		res, err := r.updateStatus(ctx, mmode, mode, ramenv1alpha1.MModeStateProgressing, nil)
-		if err != nil {
-			return res, err
-		}
+		SetStatus(ctx, mmode, mode, ramenv1alpha1.MModeStateProgressing, nil)
 		switch mode {
-		case ramenv1alpha1.MMode(ramenv1alpha1.ActionFailover):
+		case ramenv1alpha1.MModeFailover:
 			var replicas int
 			if scaleDown {
 				klog.Info("Scaling down RBD mirror deployments")
@@ -122,18 +130,12 @@ func (r *MaintenanceModeReconciler) startMaintenanceActions(ctx context.Context,
 				klog.Info("Scaling up RBD mirror deployments")
 				replicas = 1
 			}
-			_, err := r.scaleRBDMirrorDeployment(ctx, clusters, replicas)
+			_, err := r.scaleRBDMirrorDeployment(ctx, *cluster, replicas)
 			if err != nil {
-				res, statusErr := r.updateStatus(ctx, mmode, mode, ramenv1alpha1.MModeStateError, err)
-				if statusErr != nil {
-					return res, fmt.Errorf("failed to update error status %v while having error %v", statusErr, err)
-				}
-				return res, err
+				SetStatus(ctx, mmode, mode, ramenv1alpha1.MModeStateError, err)
+				return ctrl.Result{}, err
 			}
-			res, err = r.updateStatus(ctx, mmode, mode, ramenv1alpha1.MModeStateCompleted, nil)
-			if err != nil {
-				return res, err
-			}
+			SetStatus(ctx, mmode, mode, ramenv1alpha1.MModeStateCompleted, nil)
 		default:
 			return ctrl.Result{}, fmt.Errorf("no actions found for %q mode", mode)
 		}
@@ -141,43 +143,75 @@ func (r *MaintenanceModeReconciler) startMaintenanceActions(ctx context.Context,
 	return ctrl.Result{}, nil
 }
 
-func (r *MaintenanceModeReconciler) scaleRBDMirrorDeployment(ctx context.Context, clusters []rookv1.CephCluster, replicas int) (ctrl.Result, error) {
-	for _, cephCluster := range clusters {
-		deployments, err := GetDeploymentsStartingWith(ctx, r.SpokeClient, cephCluster.Namespace, RBDMirrorDeploymentNamePrefix)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+func (r *MaintenanceModeReconciler) scaleRBDMirrorDeployment(ctx context.Context, cluster rookv1.CephCluster, replicas int) (ctrl.Result, error) {
+	isMirroringEnabled, err := r.isStorageClusterMirroringEnabled(ctx, cluster)
+	if err != nil {
+		klog.Errorf("error occurred on checking mirroring enablement on storagecluster for cephcluster %s", cluster.Name)
+		return ctrl.Result{}, err
+	}
+	if !isMirroringEnabled {
+		klog.Info("storagecluster mirroring is not enabled yet. please enable it manually or wait for it to be enabled to perform further maintenance actions")
+		return ctrl.Result{Requeue: true}, nil
+	}
+	deployments, err := GetDeploymentsStartingWith(ctx, r.SpokeClient, cluster.Namespace, RBDMirrorDeploymentNamePrefix)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
-		for _, deploymentName := range deployments {
-			err = scaleDeployment(ctx, r.SpokeClient, deploymentName, cephCluster.Namespace, int32(replicas))
-			return ctrl.Result{}, err
-		}
+	for _, deploymentName := range deployments {
+		err = utils.ScaleDeployment(ctx, r.SpokeClient, deploymentName, cluster.Namespace, int32(replicas))
+		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }
 
-func (r *MaintenanceModeReconciler) updateStatus(ctx context.Context, mmode ramenv1alpha1.MaintenanceMode, mode ramenv1alpha1.MMode, state ramenv1alpha1.MModeState, err error) (ctrl.Result, error) {
+// Checks the mirroring status of the storagecluster. Deployment will not be present if mirroring is not enabled.
+func (r *MaintenanceModeReconciler) isStorageClusterMirroringEnabled(ctx context.Context, cephCluster rookv1.CephCluster) (bool, error) {
+	var sc ocsv1.StorageCluster
+	scName := getOwnerName(cephCluster)
+	if scName == "" {
+		return false, fmt.Errorf("no storagecluster found for given cephcluster %s", cephCluster.Name)
+	}
+	err := r.SpokeClient.Get(ctx, types.NamespacedName{Name: scName, Namespace: cephCluster.Namespace}, &sc)
+	if err != nil {
+		klog.Errorf("no storagecluster found for given cephcluster %s", cephCluster.Name)
+		return false, err
+	}
+	return true, nil
+}
+
+func getOwnerName(cluster rookv1.CephCluster) string {
+	for _, owner := range cluster.OwnerReferences {
+		if owner.Kind != "StorageCluster" {
+			continue
+		}
+		return owner.Name
+	}
+	return ""
+}
+
+func SetStatus(ctx context.Context, mmode ramenv1alpha1.MaintenanceMode, mode ramenv1alpha1.MMode, state ramenv1alpha1.MModeState, err error) {
 	klog.Infof("mode: %s, status: %s, generation: %d, error: %v ", mode, state, mmode.Generation, err)
 	mmode.Status.State = state
 	mmode.Status.ObservedGeneration = mmode.Generation
-	var conditions []metav1.Condition
+	var conditions = make([]metav1.Condition, 0)
 	if len(mmode.Status.Conditions) == 0 {
-		conditions = make([]metav1.Condition, 0)
 		conditions = append(conditions, newCondition(state, mode, mmode.Generation, err))
+	} else {
+		conditions = append(conditions, mmode.Status.Conditions...)
 	}
 	k8smeta.SetStatusCondition(&conditions, newCondition(state, mode, mmode.Generation, err))
 	mmode.Status.Conditions = conditions
-	statusErr := r.SpokeClient.Status().Update(ctx, &mmode)
-	if statusErr != nil {
-		klog.Error(statusErr)
-		if k8serrors.IsConflict(statusErr) {
-			// The object is being updated, and we need to requeue the request again for updates.
-			klog.Info("the object is being updated, retrying the request again...")
-			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
-		}
-		return ctrl.Result{}, statusErr
+}
+
+func (r *MaintenanceModeReconciler) fetchLatestVersionMMode(ctx context.Context, name string) (*ramenv1alpha1.MaintenanceMode, error) {
+	var mmode ramenv1alpha1.MaintenanceMode
+	err := r.SpokeClient.Get(ctx, types.NamespacedName{Name: name}, &mmode)
+	if err != nil {
+		klog.Errorf("error occurred while fetching the latest version of %s", name)
+		return nil, err
 	}
-	return ctrl.Result{}, nil
+	return &mmode, nil
 }
 
 func newCondition(state ramenv1alpha1.MModeState, mode ramenv1alpha1.MMode, generation int64, err error) metav1.Condition {
@@ -204,10 +238,9 @@ func newCondition(state ramenv1alpha1.MModeState, mode ramenv1alpha1.MMode, gene
 		status = metav1.ConditionUnknown
 	}
 	return metav1.Condition{
-		Type:               string(mode),
+		Type:               string(ramenv1alpha1.MModeConditionFailoverActivated),
 		Status:             status,
 		ObservedGeneration: generation,
-		LastTransitionTime: metav1.Now(),
 		Reason:             reason,
 		Message:            message,
 	}
@@ -215,7 +248,7 @@ func newCondition(state ramenv1alpha1.MModeState, mode ramenv1alpha1.MMode, gene
 
 func GetDeploymentsStartingWith(ctx context.Context, spokeClient client.Client, namespace string, prefix string) ([]string, error) {
 	deploymentList := &appsv1.DeploymentList{}
-	rookMirrorDeploymentLabel, err := labels.NewRequirement("app", selection.In, []string{"rook-ceph-rbd-mirror"})
+	rookMirrorDeploymentLabel, err := labels.NewRequirement("app", selection.Equals, []string{"rook-ceph-rbd-mirror"})
 	if err != nil {
 		klog.Error(err, "cannot parse new requirement")
 	}
@@ -243,56 +276,15 @@ func GetDeploymentsStartingWith(ctx context.Context, spokeClient client.Client, 
 	return deploymentNames, nil
 }
 
-func scaleDeployment(ctx context.Context, client client.Client, deploymentName string, namespace string, replicas int32) error {
-	var deployment appsv1.Deployment
-	err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: deploymentName}, &deployment)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return fmt.Errorf("deployment %s not found in namespace %s", deploymentName, namespace)
+func filterCephClustersByStorageIdOrReplicationId(clusters *rookv1.CephClusterList, targetId string, provisioner string) *rookv1.CephCluster {
+	for _, cc := range clusters.Items {
+		fullProvisionerName := fmt.Sprintf(RBDProvisionerTemplate, cc.Namespace)
+		if cc.Status.CephStatus.FSID == targetId && provisioner == fullProvisionerName {
+			return &cc
 		}
-		return err
-	}
-	deployment.Spec.Replicas = &replicas
-	err = client.Update(ctx, &deployment)
-	if err != nil {
-		return err
-	}
-	var updatedDeployment appsv1.Deployment
-	for {
-		err := client.Get(context.TODO(), types.NamespacedName{
-			Namespace: namespace, Name: deploymentName,
-		}, &updatedDeployment)
-		if err != nil {
-			return err
-		}
-		if updatedDeployment.Status.Replicas == replicas {
-			break
+		if cc.Labels != nil && cc.Labels[utils.CephClusterReplicationIdLabel] == targetId {
+			return &cc
 		}
 	}
 	return nil
-}
-
-func filterCephClustersByStorageId(clusters *rookv1.CephClusterList, storageId string, provisioner string) []rookv1.CephCluster {
-	cephClusters := make([]rookv1.CephCluster, 0)
-	for _, cc := range clusters.Items {
-		fullProvisionerName := fmt.Sprintf(RBDProvisionerTemplate, cc.Namespace)
-		if cc.Status.CephStatus.FSID == storageId && provisioner == fullProvisionerName {
-			cephClusters = append(cephClusters, cc)
-		}
-	}
-	return cephClusters
-}
-
-func fetchAllCephClusters(ctx context.Context, client client.Client) (*rookv1.CephClusterList, error) {
-	var cephClusters rookv1.CephClusterList
-	err := client.List(ctx, &cephClusters)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list CephClusters %v", err)
-	}
-
-	if len(cephClusters.Items) == 0 {
-		klog.Info("no CephClusters found on current cluster")
-		return nil, nil
-	}
-	return &cephClusters, nil
 }

--- a/addons/maintainence-agent/manager.go
+++ b/addons/maintainence-agent/manager.go
@@ -41,6 +41,7 @@ func init() {
 	utilruntime.Must(ramenv1alpha1.AddToScheme(mgrScheme))
 	utilruntime.Must(rookv1.AddToScheme(mgrScheme))
 	utilruntime.Must(appsv1.AddToScheme(mgrScheme))
+	utilruntime.Must(ocsv1.AddToScheme(mgrScheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/addons/setup/maintenance-manifests/spoke_clusterrole.yaml
+++ b/addons/setup/maintenance-manifests/spoke_clusterrole.yaml
@@ -18,3 +18,6 @@ rules:
 - apiGroups: ["ceph.rook.io"]
   resources: ["cephclusters"]
   verbs: ["get", "watch", "list"]
+- apiGroups: ["ocs.openshift.io"]
+  resources: ["storageclusters"]
+  verbs: ["get", "watch", "list"]

--- a/addons/setup/maintenance-manifests/spoke_role.yaml
+++ b/addons/setup/maintenance-manifests/spoke_role.yaml
@@ -25,3 +25,6 @@ rules:
 - apiGroups: ["ceph.rook.io"]
   resources: ["cephclusters"]
   verbs: ["get", "watch", "list"]
+- apiGroups: ["ocs.openshift.io"]
+  resources: ["storageclusters"]
+  verbs: ["get", "watch", "list"]

--- a/addons/setup/tokenexchange-manifests/spoke_clusterrole.yaml
+++ b/addons/setup/tokenexchange-manifests/spoke_clusterrole.yaml
@@ -11,7 +11,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 - apiGroups: ["ceph.rook.io"]
   resources: ["cephclusters"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch", "update"]
 - apiGroups: ["ocs.openshift.io"]
   resources: ["storageclusters"]
   verbs: ["get", "update"]

--- a/addons/setup/tokenexchange-manifests/spoke_role.yaml
+++ b/addons/setup/tokenexchange-manifests/spoke_role.yaml
@@ -22,3 +22,6 @@ rules:
 - apiGroups: ["route.openshift.io"]
   resources: ["routes"]
   verbs: ["get", "list"]
+- apiGroups: ["ceph.rook.io"]
+  resources: ["cephclusters"]
+  verbs: ["get", "list", "watch", "update"]

--- a/addons/token-exchange/agent_mirrorpeer_controller.go
+++ b/addons/token-exchange/agent_mirrorpeer_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -145,6 +146,10 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 		klog.Infof("enabling async mode dependencies")
+		err = r.labelCephClusters(ctx, scr, clusterFSIDs)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to label cephcluster: %v", err)
+		}
 		err = r.enableCSIAddons(ctx, scr.Namespace)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to start CSI Addons for rook: %v", err)
@@ -562,4 +567,44 @@ func (r *MirrorPeerReconciler) deleteMirrorPeer(ctx context.Context, mirrorPeer 
 		return ctrl.Result{}, fmt.Errorf("failed to delete s3 buckets")
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *MirrorPeerReconciler) labelCephClusters(ctx context.Context, scr *multiclusterv1alpha1.StorageClusterRef, clusterFSIDs map[string]string) error {
+	cephClusters, err := utils.FetchAllCephClusters(ctx, r.SpokeClient)
+	if cephClusters == nil || len(cephClusters.Items) == 0 {
+		klog.Info("failed to find any cephclusters to label")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var found rookv1.CephCluster
+	for _, cc := range cephClusters.Items {
+		for _, ref := range cc.OwnerReferences {
+			if ref.Kind != "StorageCluster" {
+				continue
+			}
+
+			if ref.Name == scr.Name {
+				found = cc
+				break
+			}
+		}
+	}
+	if found.Labels == nil {
+		found.Labels = make(map[string]string)
+	}
+	var fsids []string
+	for _, v := range clusterFSIDs {
+		fsids = append(fsids, v)
+	}
+	// To ensure reliability of hash generation
+	sort.Strings(fsids)
+	replicationId := utils.CreateUniqueReplicationId(fsids)
+	found.Labels[utils.CephClusterReplicationIdLabel] = replicationId
+	err = r.SpokeClient.Update(ctx, &found)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/addons/token-exchange/manager.go
+++ b/addons/token-exchange/manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 
+	rookv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/replication.storage/v1alpha1"
 	obv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -41,6 +43,7 @@ func init() {
 	utilruntime.Must(obv1alpha1.AddToScheme(mgrScheme))
 	utilruntime.Must(routev1.AddToScheme(mgrScheme))
 	utilruntime.Must(submarinerv1alpha1.AddToScheme(mgrScheme))
+	utilruntime.Must(rookv1.AddToScheme(mgrScheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -65,6 +65,13 @@ spec:
               manageS3:
                 default: false
                 type: boolean
+              overlappingCIDR:
+                default: false
+                description: OverlappingCIDR should be set to true if the peer clusters
+                  have overlapping Pod or Service CIDR. This will enable storage clusters
+                  to use submariner globalnet. Enabling this will cause storage service
+                  disruption while network is being reconfigured.
+                type: boolean
               schedulingIntervals:
                 description: 'SchedulingIntervals is a list of intervals at which
                   mirroring snapshots are taken. DEPRECATED :  Any changes to this

--- a/controllers/manager.go
+++ b/controllers/manager.go
@@ -3,15 +3,14 @@ package controllers
 import (
 	"context"
 	"flag"
-	"github.com/red-hat-storage/odf-multicluster-orchestrator/addons/setup"
-	"github.com/red-hat-storage/odf-multicluster-orchestrator/console"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
 	"github.com/openshift/library-go/pkg/operator/events"
 	ramenv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/addons/setup"
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/console"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,6 +24,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var (

--- a/controllers/utils/cluster.go
+++ b/controllers/utils/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
+	rookv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,4 +61,13 @@ func ScaleDeployment(ctx context.Context, client client.Client, deploymentName s
 	}
 
 	return nil
+}
+
+func FetchAllCephClusters(ctx context.Context, client client.Client) (*rookv1.CephClusterList, error) {
+	var cephClusters rookv1.CephClusterList
+	err := client.List(ctx, &cephClusters)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list CephClusters %v", err)
+	}
+	return &cephClusters, nil
 }

--- a/controllers/utils/cluster.go
+++ b/controllers/utils/cluster.go
@@ -2,7 +2,10 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -10,9 +13,10 @@ import (
 type ClusterType string
 
 const (
-	CONVERGED ClusterType = "Converged"
-	EXTERNAL  ClusterType = "External"
-	UNKNOWN   ClusterType = "Unknown"
+	CONVERGED                     ClusterType = "Converged"
+	EXTERNAL                      ClusterType = "External"
+	UNKNOWN                       ClusterType = "Unknown"
+	CephClusterReplicationIdLabel             = "replicationid.multicluster.openshift.io"
 )
 
 func GetClusterType(storageClusterName string, namespace string, client client.Client) (ClusterType, error) {
@@ -25,4 +29,35 @@ func GetClusterType(storageClusterName string, namespace string, client client.C
 		return EXTERNAL, nil
 	}
 	return CONVERGED, nil
+}
+
+func ScaleDeployment(ctx context.Context, client client.Client, deploymentName string, namespace string, replicas int32) error {
+	var deployment appsv1.Deployment
+	err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: deploymentName}, &deployment)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return fmt.Errorf("deployment %s not found in namespace %s", deploymentName, namespace)
+		}
+		return err
+	}
+	deployment.Spec.Replicas = &replicas
+	err = client.Update(ctx, &deployment)
+	if err != nil {
+		return err
+	}
+
+	var updatedDeployment appsv1.Deployment
+	for {
+		err := client.Get(context.TODO(), types.NamespacedName{
+			Namespace: namespace, Name: deploymentName,
+		}, &updatedDeployment)
+		if err != nil {
+			return err
+		}
+		if updatedDeployment.Status.Replicas == replicas {
+			break
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This commit fixes the following issues -
1. Conflict error issues with the finalizer
2. Checks if StorageCluster mirroring is enabled before scaling.
3. Status update done at the end of reconciliation
4. Returns only a single cephcluster instead of an array as the targetId should only return single unique cephcluster