### PR TITLE
Removes rook-client usage

### DIFF
--- a/addons/token-exchange/secret_exchange_handler_register.go
+++ b/addons/token-exchange/secret_exchange_handler_register.go
@@ -2,9 +2,9 @@ package addons
 
 import (
 	"fmt"
+
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/utils"
-	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	"k8s.io/client-go/rest"
 )
 
@@ -18,11 +18,6 @@ var secretExchangeHandler *SecretExchangeHandler
 func registerHandler(mode multiclusterv1alpha1.DRType, spokeKubeConfig *rest.Config, hubKubeConfig *rest.Config) error {
 	if mode != multiclusterv1alpha1.Sync && mode != multiclusterv1alpha1.Async {
 		return fmt.Errorf("unknown mode %q detected, please check the mirrorpeer created", mode)
-	}
-	// rook specific client
-	rookClient, err := rookclient.NewForConfig(spokeKubeConfig)
-	if err != nil {
-		return fmt.Errorf("failed to add rook client: %v", err)
 	}
 
 	// a generic client which is common between all handlers
@@ -44,7 +39,6 @@ func registerHandler(mode multiclusterv1alpha1.DRType, spokeKubeConfig *rest.Con
 		hubClient:   genericHubClient,
 	}
 	secretExchangeHandler.RegisteredHandlers[utils.RookSecretHandlerName] = rookSecretHandler{
-		rookClient:  rookClient,
 		spokeClient: genericSpokeClient,
 		hubClient:   genericHubClient,
 	}


### PR DESCRIPTION
This commit removes the usages of rook-client and replaces them with controller runtime dependencies.