### PR TITLE
Fetches cluster fsid through secret and not mc

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,9 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        ports:
+        - containerPort: 8081
+          protocol: TCP
         env:
         - name: TOKEN_EXCHANGE_IMAGE
           value: ${IMG}


### PR DESCRIPTION
This commit fixes the issue with hub recovery where the new hub cluster does not have managedcluster CRs updated due to clusterclaims on the managed clusters being in an non updated state.

We are changing the method from looking into the MC CRs to fetching it from the rook secret synced on hub.