### PR TITLE
Add hub recovery labels for backing up secrets

### DIFF
--- a/addons/blue_secret_controller.go
+++ b/addons/blue_secret_controller.go
@@ -49,7 +49,7 @@ func (r *BlueSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("bluesecret_controller").
 		Watches(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}, blueSecretPredicate)).
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}, blueSecretPredicate)).
 		Complete(r)
 }
 

--- a/addons/secret_exchange_handler_utils.go
+++ b/addons/secret_exchange_handler_utils.go
@@ -32,6 +32,7 @@ func generateBlueSecret(secret corev1.Secret, secretType utils.SecretLabelType, 
 			Namespace: managedCluster,
 			Labels: map[string]string{
 				utils.SecretLabelTypeKey: string(secretType),
+				utils.HubRecoveryLabel:   "",
 			},
 		},
 		Type: utils.SecretLabelTypeKey,
@@ -61,6 +62,7 @@ func generateBlueSecretForExternal(rookCephMon corev1.Secret, labelType utils.Se
 			Namespace: managedClusterName,
 			Labels: map[string]string{
 				utils.SecretLabelTypeKey: string(labelType),
+				utils.HubRecoveryLabel:   "",
 			},
 		},
 		Type: utils.SecretLabelTypeKey,

--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -52,7 +52,6 @@ type MirrorPeerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-const hubRecoveryLabel = "cluster.open-cluster-management.io/backup"
 const mirrorPeerFinalizer = "hub.multicluster.odf.openshift.io"
 const spokeClusterRoleBindingName = "spoke-clusterrole-bindings"
 
@@ -160,9 +159,9 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		mirrorPeerCopy.Labels = make(map[string]string)
 	}
 
-	if val, ok := mirrorPeerCopy.Labels[hubRecoveryLabel]; !ok || val != "resource" {
+	if val, ok := mirrorPeerCopy.Labels[utils.HubRecoveryLabel]; !ok || val != "resource" {
 		logger.Info("Adding label to mirrorpeer for disaster recovery")
-		mirrorPeerCopy.Labels[hubRecoveryLabel] = "resource"
+		mirrorPeerCopy.Labels[utils.HubRecoveryLabel] = "resource"
 		err = r.Client.Update(ctx, mirrorPeerCopy)
 
 		if err != nil {

--- a/controllers/mirrorpeer_controller_test.go
+++ b/controllers/mirrorpeer_controller_test.go
@@ -21,6 +21,8 @@ package controllers
 
 import (
 	"context"
+	"testing"
+
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/addons/setup"
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/utils"
@@ -31,7 +33,6 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 func TestMirrorPeerReconcilerReconcile(t *testing.T) {
@@ -80,8 +81,8 @@ func TestMirrorPeerReconcilerReconcile(t *testing.T) {
 		t.Errorf("Failed to get MirrorPeer. Error: %s", err)
 	}
 
-	if val, ok := mp.Labels[hubRecoveryLabel]; !ok || val != "resource" {
-		t.Errorf("MirrorPeer.Labels[%s] is not set correctly. Expected: %s, Actual: %s", hubRecoveryLabel, "resource", val)
+	if val, ok := mp.Labels[utils.HubRecoveryLabel]; !ok || val != "resource" {
+		t.Errorf("MirrorPeer.Labels[%s] is not set correctly. Expected: %s, Actual: %s", utils.HubRecoveryLabel, "resource", val)
 	}
 }
 

--- a/controllers/utils/secret.go
+++ b/controllers/utils/secret.go
@@ -30,6 +30,7 @@ const (
 	MirrorPeerSecret                      = "mirrorpeersecret"
 	RookTokenKey                          = "token"
 	ClusterTypeKey                        = "cluster_type"
+	HubRecoveryLabel                      = "cluster.open-cluster-management.io/backup"
 )
 
 type RookToken struct {
@@ -129,6 +130,10 @@ func ValidateSourceSecret(sourceSecret *corev1.Secret) error {
 // ValidateDestinationSecret validates whether the given secret is a Destination type
 func ValidateDestinationSecret(sourceSecret *corev1.Secret) error {
 	return ValidateInternalSecret(sourceSecret, DestinationLabel)
+}
+
+func HasHubRecoveryLabels(secret *corev1.Secret) bool {
+	return secret.ObjectMeta.Labels[HubRecoveryLabel] == ""
 }
 
 func ValidateS3Secret(data map[string][]byte) bool {


### PR DESCRIPTION
These commits add label changes to the generated source secret as well as the ones present on the hub to make them a candidate for ACM backup and restore (https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html-single/backup_and_restore)

This is done as a fix to hub recovery issue where secrets are not generated due when both the active hub and primary cluster being co-situated on the same site or zone. This causes the VRC to not be created on the remaining managed clusters and failover fails.
