### PR TITLE
Check and update only those fields that MCO is interested in S3Profiles

### DIFF
--- a/controllers/common_controller_utils.go
+++ b/controllers/common_controller_utils.go
@@ -232,6 +232,38 @@ func isS3ProfileManagedPeerRef(clusterPeerRef multiclusterv1alpha1.PeerRef, mirr
 	return false
 }
 
+func updateS3ProfileFields(expected *rmn.S3StoreProfile, found *rmn.S3StoreProfile) {
+	found.S3ProfileName = expected.S3ProfileName
+	found.S3Bucket = expected.S3Bucket
+	found.S3Region = expected.S3Region
+	found.S3CompatibleEndpoint = expected.S3CompatibleEndpoint
+	found.S3SecretRef.Name = expected.S3SecretRef.Name
+}
+
+func areS3ProfileFieldsEqual(expected rmn.S3StoreProfile, found rmn.S3StoreProfile) bool {
+	if expected.S3ProfileName != found.S3ProfileName {
+		return false
+	}
+
+	if expected.S3Bucket != found.S3Bucket {
+		return false
+	}
+
+	if expected.S3Region != found.S3Region {
+		return false
+	}
+
+	if expected.S3CompatibleEndpoint != found.S3CompatibleEndpoint {
+		return false
+	}
+
+	if expected.S3SecretRef.Name != found.S3SecretRef.Name {
+		return false
+	}
+
+	return true
+}
+
 func updateRamenHubOperatorConfig(ctx context.Context, rc client.Client, secret *corev1.Secret, data map[string][]byte, mirrorPeers []multiclusterv1alpha1.MirrorPeer, ramenHubNamespace string) error {
 	logger := log.FromContext(ctx)
 
@@ -296,12 +328,12 @@ func updateRamenHubOperatorConfig(ctx context.Context, rc client.Client, secret 
 	for i, currentS3Profile := range ramenConfig.S3StoreProfiles {
 		if currentS3Profile.S3ProfileName == expectedS3Profile.S3ProfileName {
 
-			if reflect.DeepEqual(expectedS3Profile, currentS3Profile) {
+			if areS3ProfileFieldsEqual(expectedS3Profile, currentS3Profile) {
 				// no change detected on already exiting s3 profile in RamenConfig
 				return nil
 			}
 			// changes deducted on existing s3 profile
-			ramenConfig.S3StoreProfiles[i] = expectedS3Profile
+			updateS3ProfileFields(&expectedS3Profile, &ramenConfig.S3StoreProfiles[i])
 			isUpdated = true
 			break
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.31.1
 	github.com/openshift/api v0.0.0-20240124164020-e2ce40831f2e
 	github.com/openshift/library-go v0.0.0-20240124134907-4dfbf6bc7b11
-	github.com/ramendr/ramen/api v0.0.0-20240321110022-975f2fbf6dce
+	github.com/ramendr/ramen/api v0.0.0-20240409201920-10024cae3bfd
 	github.com/red-hat-storage/ocs-operator v0.4.13
 	github.com/rook/rook/pkg/apis v0.0.0-20231204200402-5287527732f7
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -707,8 +707,8 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/ramendr/ramen/api v0.0.0-20240321110022-975f2fbf6dce h1:1KO6EV5JsFOCBMA1rYVo5jP8fNCXAHEMh6rbhXd6TLg=
-github.com/ramendr/ramen/api v0.0.0-20240321110022-975f2fbf6dce/go.mod h1:PCb0ODjdi4eYuxY/nSw+/rQqmzkmBVqGNoDr2JXdlKE=
+github.com/ramendr/ramen/api v0.0.0-20240409201920-10024cae3bfd h1:TsDaQqfb1BcR78JWXBmUyj6Qx4By5loUZ95CxmA/6zo=
+github.com/ramendr/ramen/api v0.0.0-20240409201920-10024cae3bfd/go.mod h1:PCb0ODjdi4eYuxY/nSw+/rQqmzkmBVqGNoDr2JXdlKE=
 github.com/red-hat-storage/ocs-operator v0.4.13 h1:+FdRGqgewn7v22LvhQUV8iSzLm8d6k4T+zyX0Zjo7qw=
 github.com/red-hat-storage/ocs-operator v0.4.13/go.mod h1:92CGJGBXykejC89+h8s0pohpb0JRwfwPE9IwUNF5+sY=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
Ramen S3Profiles spec has two more fields which are related to velero/OADP and they are not managed by MCO. However, MCO is currently overwriting them when s3 profile updates. This PR addresses that.