### PR TITLE
create VRC with flattenMode=force

### DIFF
--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -60,6 +60,11 @@ func TestDRPolicyReconcile(t *testing.T) {
 		Spec: ramenv1alpha1.DRPolicySpec{
 			SchedulingInterval: "1h",
 			DRClusters:         []string{cName1, cName2},
+			ReplicationClassSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					RBDFlattenVolumeReplicationClassLabelKey: RBDFlattenVolumeReplicationClassLabelValue,
+				},
+			},
 		},
 	}
 
@@ -87,6 +92,9 @@ func TestDRPolicyReconcile(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("Failed to get ManifestWork. Error: %s", err)
+		}
+		if len(found.Spec.Workload.Manifests) < 2 {
+			t.Errorf("Expected at least 2 VRC")
 		}
 	}
 }


### PR DESCRIPTION
If DRPolicy is created with flattening enabled, we create 2 VRC - 1 without flattening and 1 with flattening. VRC without flattening is marked as default VRC and VRC with flattening is given a unique label.