### PR TITLE
remove unused configuration of MultiClusterService

### DIFF
--- a/addons/manager.go
+++ b/addons/manager.go
@@ -16,7 +16,6 @@ import (
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	rookv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/spf13/cobra"
-	submarinerv1alpha1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -57,7 +56,6 @@ func init() {
 	utilruntime.Must(ocsv1.AddToScheme(mgrScheme))
 	utilruntime.Must(obv1alpha1.AddToScheme(mgrScheme))
 	utilruntime.Must(routev1.AddToScheme(mgrScheme))
-	utilruntime.Must(submarinerv1alpha1.AddToScheme(mgrScheme))
 	utilruntime.Must(rookv1.AddToScheme(mgrScheme))
 	utilruntime.Must(extv1.AddToScheme(mgrScheme))
 	//+kubebuilder:scaffold:scheme

--- a/api/v1alpha1/mirrorpeer_types.go
+++ b/api/v1alpha1/mirrorpeer_types.go
@@ -69,14 +69,6 @@ type MirrorPeerSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	ManageS3 bool `json:"manageS3,omitempty"`
-
-	// OverlappingCIDR should be set to true if the peer clusters
-	// have overlapping Pod or Service CIDR. This will enable storage
-	// clusters to use submariner globalnet. Enabling this will cause
-	// storage service disruption while network is being reconfigured.
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
-	OverlappingCIDR bool `json:"overlappingCIDR,omitempty"`
 }
 
 // MirrorPeerStatus defines the observed state of MirrorPeer

--- a/api/v1alpha1/mirrorpeer_webhook.go
+++ b/api/v1alpha1/mirrorpeer_webhook.go
@@ -80,9 +80,6 @@ func (r *MirrorPeer) ValidateUpdate(old runtime.Object) (warnings admission.Warn
 		}
 	}
 
-	if oldMirrorPeer.Spec.OverlappingCIDR && !r.Spec.OverlappingCIDR {
-		return []string{}, fmt.Errorf("error updating MirrorPeer: OverlappingCIDR value can not be changed from %t to %t. This is to prevent Disaster Recovery from being unusable between clusters that have overlapping IPs", oldMirrorPeer.Spec.OverlappingCIDR, r.Spec.OverlappingCIDR)
-	}
 	return []string{}, validateMirrorPeer(r)
 }
 

--- a/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/bundle/manifests/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -72,14 +72,6 @@ spec:
               manageS3:
                 default: false
                 type: boolean
-              overlappingCIDR:
-                default: false
-                description: |-
-                  OverlappingCIDR should be set to true if the peer clusters
-                  have overlapping Pod or Service CIDR. This will enable storage
-                  clusters to use submariner globalnet. Enabling this will cause
-                  storage service disruption while network is being reconfigured.
-                type: boolean
               schedulingIntervals:
                 description: |-
                   SchedulingIntervals is a list of intervals at which mirroring snapshots are taken.

--- a/config/crd/bases/multicluster.odf.openshift.io_mirrorpeers.yaml
+++ b/config/crd/bases/multicluster.odf.openshift.io_mirrorpeers.yaml
@@ -72,14 +72,6 @@ spec:
               manageS3:
                 default: false
                 type: boolean
-              overlappingCIDR:
-                default: false
-                description: |-
-                  OverlappingCIDR should be set to true if the peer clusters
-                  have overlapping Pod or Service CIDR. This will enable storage
-                  clusters to use submariner globalnet. Enabling this will cause
-                  storage service disruption while network is being reconfigured.
-                type: boolean
               schedulingIntervals:
                 description: |-
                   SchedulingIntervals is a list of intervals at which mirroring snapshots are taken.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/rook/rook/pkg/apis v0.0.0-20231204200402-5287527732f7
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
-	github.com/submariner-io/submariner-operator v0.17.0
 	golang.org/x/sync v0.5.0
 	k8s.io/api v0.29.2
 	k8s.io/apiextensions-apiserver v0.29.2
@@ -52,6 +51,7 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3 // indirect
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -93,8 +93,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stolostron/multicloud-operators-placementrule v1.2.4-1-20220311-8eedb3f.0.20230828200208-cd3c119a7fa0 // indirect
-	github.com/submariner-io/admiral v0.17.0 // indirect
-	github.com/submariner-io/submariner v0.17.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -778,12 +778,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/submariner-io/admiral v0.17.0 h1:Hz722z70W8hPAlKv/Y70MhNGwmmjl4eMZ+bDw9S+BAQ=
-github.com/submariner-io/admiral v0.17.0/go.mod h1:OYkNN5EYaMZ1w1qxzVzD5q8hVNtojQkVoNPcO8/LL+Y=
-github.com/submariner-io/submariner v0.17.0 h1:IrD2kqf+2pTLw5ldNycoPv7eKURngQWaQ06vX7/pvPY=
-github.com/submariner-io/submariner v0.17.0/go.mod h1:mD6agq0P2OGSXHb74lblkSxGgxP7vy9/sa4ghzJBd1E=
-github.com/submariner-io/submariner-operator v0.17.0 h1:7fQW/KAaCTP4HPzaIN0w/9u8j1rqwpQTfLjU2F+Z0zg=
-github.com/submariner-io/submariner-operator v0.17.0/go.mod h1:/DrA6G1ll97bmyMvPDVj2OKU0htQUrYY0MtOpzlYM9I=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
MirrorPeer.Spec.OverlappingCIDR was added to allow users to automatically enable StorageCluster.Spec.Netowrking.MultiClusterService when needed. But this implementation had some limitations due to which it was not generally used.

This commit now drops the changes completely to avoid unwanted usage. This will be replaced by alternate solutions which are more reliable.