### PR TITLE
Refactor Makefile to support customizable build tool

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -31,7 +31,7 @@ jobs:
         go-version: ${{ matrix.go }}
 
     - name: Build
-      run: make docker-build
+      run: make operator-build
 
     - name: Login to Quay
       uses: docker/login-action@v1
@@ -41,7 +41,7 @@ jobs:
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
     - name: Push
-      run: make docker-push
+      run: make operator-push
 
   publish-bundle:
     name: Bundle Image

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -84,7 +84,7 @@ jobs:
         go-version: ${{ matrix.go }}
 
     - name: Build
-      run: make docker-build
+      run: make operator-build
 
   validate-bundle:
     name: Validate Operator Bundle

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,11 @@ build: generate fmt vet golangci-lint kube-linter ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
-docker-build: generate fmt vet golangci-lint kube-linter ## Build docker image with the manager.
-	docker build -t ${IMG} .
+operator-build: generate fmt vet golangci-lint kube-linter ## Build docker image with the manager.
+	${BUILD_TOOL} build -t ${IMG} .
 
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+operator-push: ## Push docker image with the manager.
+	${BUILD_TOOL} push ${IMG}
 
 ##@ Deployment
 
@@ -117,19 +117,19 @@ endif
 
 .PHONY: bundle-build
 bundle-build: bundle ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	${BUILD_TOOL} build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+	$(MAKE) operator-push IMG=$(BUNDLE_IMG)
 
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool ${BUILD_TOOL} --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+	$(MAKE) operator-push IMG=$(CATALOG_IMG)
 
 ##@ Actions
 

--- a/hack/make/vars.mk
+++ b/hack/make/vars.mk
@@ -22,6 +22,7 @@ MULTICLUSTER_CONSOLE_IMG_TAG ?= latest
 IMG ?=  $(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG)
 MULTICLUSTER_CONSOLE_IMG ?= ${IMAGE_REGISTRY}/$(REGISTRY_NAMESPACE)/$(MULTICLUSTER_CONSOLE_IMG_NAME):$(MULTICLUSTER_CONSOLE_IMG_TAG)
 
+BUILD_TOOL ?= docker
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:


### PR DESCRIPTION
This change provides the flexibility to use different container build tools by simply setting the `BUILD_TOOL` variable.