### PR TITLE
Move to multi-cluster controller with added resiliency of managed resources

### DIFF
--- a/addons/manager.go
+++ b/addons/manager.go
@@ -216,6 +216,7 @@ func (o *AddonAgentOptions) RunAgent(ctx context.Context) {
 
 	if err = (&BlueSecretReconciler{
 		Scheme:           mgr.GetScheme(),
+		HubCluster:       hubCluster,
 		HubClient:        hubCluster.GetClient(),
 		SpokeClient:      mgr.GetClient(),
 		SpokeClusterName: o.SpokeClusterName,
@@ -227,6 +228,7 @@ func (o *AddonAgentOptions) RunAgent(ctx context.Context) {
 
 	if err = (&S3SecretReconciler{
 		Scheme:           mgr.GetScheme(),
+		HubCluster:       hubCluster,
 		HubClient:        hubCluster.GetClient(),
 		SpokeClient:      mgr.GetClient(),
 		SpokeClusterName: o.SpokeClusterName,


### PR DESCRIPTION
Until now, blue secret controller only watched for resources on local cluster and replicated it to the hub. In case the resource gets deleted on the hub, it would not be reconciled until a reconcile is triggered from the local cluster.
Similarly, green secret controller only watched resources on the hub and replicated it to local cluster. In case the resource gets deleted on the local cluster, it would not be reconciled until a reconcile is triggered from the hub cluster.

With this change, each of these controllers will watch for the resources that it creates on a different cluster and immediately reconciles in when a change is observed.