### PR TITLE
Bug 2308144: Correct ConfigMap creation logic and update unit tests

### DIFF
--- a/controllers/managedclusterview_controller_test.go
+++ b/controllers/managedclusterview_controller_test.go
@@ -34,7 +34,9 @@ func TestCreateOrUpdateConfigMap(t *testing.T) {
 	logger := utils.GetLogger(utils.GetZapLogger(true))
 
 	createManagedClusterView := func(name, namespace string, data map[string]string, ownerRefs []metav1.OwnerReference) *viewv1beta1.ManagedClusterView {
-		raw, _ := json.Marshal(data)
+		raw, _ := json.Marshal(map[string]interface{}{
+			"data": data,
+		})
 		return &viewv1beta1.ManagedClusterView{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            name,


### PR DESCRIPTION
- Updated the `createOrUpdateConfigMap` function to handle nested data structures correctly, ensuring that YAML content is properly extracted and parsed.
- Adjusted the logic to filter for YAML keys in the ManagedClusterView data and marshal the parsed data into JSON for storage in the ConfigMap.
- Ensured that the `Controller` field in the OwnerReferences is set to `false` where necessary to prevent conflicts.
- Modified unit tests to reflect the changes in the data structure and logic, ensuring accurate validation of the ConfigMap content and OwnerReferences.
- Fixed a bug where the `Scope` check in the `hasODFInfoInScope` function was incorrectly using `Kind` instead of `Resource`.