### PR TITLE
Initialize Mirroring spec to avoid nil pointer exception

### DIFF
--- a/addons/agent_mirrorpeer_controller.go
+++ b/addons/agent_mirrorpeer_controller.go
@@ -374,6 +374,9 @@ func (r *MirrorPeerReconciler) toggleMirroring(ctx context.Context, storageClust
 
 	// Determine if mirroring should be enabled or disabled
 	if enabled {
+		if sc.Spec.Mirroring == nil {
+			sc.Spec.Mirroring = &ocsv1.MirroringSpec{}
+		}
 		oppPeers := getOppositePeerRefs(mp, r.SpokeClusterName)
 		if hasRequiredSecret(sc.Spec.Mirroring.PeerSecretNames, oppPeers) {
 			sc.Spec.Mirroring.Enabled = true
@@ -382,7 +385,7 @@ func (r *MirrorPeerReconciler) toggleMirroring(ctx context.Context, storageClust
 			return fmt.Errorf("StorageCluster %q does not have required PeerSecrets", storageClusterName)
 		}
 	} else {
-		sc.Spec.Mirroring.Enabled = false
+		sc.Spec.Mirroring = nil
 		r.Logger.Info("Mirroring disabled on StorageCluster", "storageClusterName", storageClusterName)
 	}
 

--- a/addons/agent_mirrorpeer_controller_test.go
+++ b/addons/agent_mirrorpeer_controller_test.go
@@ -246,7 +246,7 @@ func TestDisableMirroring(t *testing.T) {
 			t.Error("failed to get storage cluster", err)
 		}
 
-		if sc.Spec.Mirroring.Enabled {
+		if sc.Spec.Mirroring != nil {
 			t.Error("failed to disable mirroring")
 		}
 	}

--- a/addons/rook_secret_handler.go
+++ b/addons/rook_secret_handler.go
@@ -197,6 +197,9 @@ func updateStorageCluster(secretName, storageClusterName, storageClusterNamespac
 	}
 
 	// Update secret name
+	if sc.Spec.Mirroring == nil {
+		sc.Spec.Mirroring = &ocsv1.MirroringSpec{}
+	}
 	if !utils.ContainsString(sc.Spec.Mirroring.PeerSecretNames, secretName) {
 		sc.Spec.Mirroring.PeerSecretNames = append(sc.Spec.Mirroring.PeerSecretNames, secretName)
 		err := spokeClient.Update(ctx, sc)


### PR DESCRIPTION
OCS operator API dependency has been changed recently,
 MirroringSpec is changed to pointer: [https://github.com/red-hat-storage/ocs-operator/commit/24092a02c1c1288ac8f96bf89aeb17280fa49d3a#diff-56afead82aaf51a0042[…]ed85210d2b6eed847d3f87R89](https://github.com/red-hat-storage/ocs-operator/commit/24092a02c1c1288ac8f96bf89aeb17280fa49d3a#diff-56afead82aaf51a00424b12238a93c094ce469f981ed85210d2b6eed847d3f87R89)
 
 
So the recent, OCS API dependency on MCO is started breaking with nil pointer exception: [https://github.com/red-hat-storage/odf-multicluster-orchestrator/commit/5899bfa27128c0120f5c083a97977d60c0288404#diff-3295df72345[…]8042d9f42d63R734](https://github.com/red-hat-storage/odf-multicluster-orchestrator/commit/5899bfa27128c0120f5c083a97977d60c0288404#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63R734)
