### PR TITLE
Fix issue with the hash generation for MirrorPeer

### DIFF
--- a/controllers/utils/hash.go
+++ b/controllers/utils/hash.go
@@ -61,23 +61,23 @@ func CreateUniqueReplicationId(clusterFSIDs map[string]string) (string, error) {
 }
 
 func GenerateUniqueIdForMirrorPeer(mirrorPeer multiclusterv1alpha1.MirrorPeer, hasStorageClientRef bool) string {
-	var peerAccumulator []string
-
+	var checksum [20]byte
 	if hasStorageClientRef {
+		var peerAccumulator []string
 		for _, peer := range mirrorPeer.Spec.Items {
 			peerAccumulator = append(peerAccumulator, GetKey(peer.ClusterName, peer.StorageClusterRef.Name))
 		}
+		sort.Strings(peerAccumulator)
+		checksum = sha1.Sum([]byte(strings.Join(peerAccumulator, "-")))
 	} else {
+		var peerAccumulator string
 		for _, peer := range mirrorPeer.Spec.Items {
-			peerAccumulator = append(peerAccumulator, peer.ClusterName)
+			peerAccumulator += peer.ClusterName
 		}
-
+		checksum = sha1.Sum([]byte(peerAccumulator))
 	}
-
-	sort.Strings(peerAccumulator)
-
-	checksum := sha1.Sum([]byte(strings.Join(peerAccumulator, "-")))
-	return hex.EncodeToString(checksum[:])
+	// truncate to bucketGenerateName + "-" + first 12 (out of 20) byte representations of sha1 checksum
+	return hex.EncodeToString(checksum[:])[0 : len(BucketGenerateName)+1+12]
 }
 
 func GetKey(clusterName, clientName string) string {


### PR DESCRIPTION
There are two separate methods to generate hashes based on whether RDR is done for provider mode or internal mode

The one for internal mode is being reverted in this commit as the it was causing issues with upgrades

https://issues.redhat.com/browse/DFBUGS-961