### PR TITLE
addons: move the fetching of cephfsid only for non-provider mode

### DIFF
--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -1089,7 +1089,7 @@ func (r *MirrorPeerReconciler) updateMirrorPeerStatus(ctx context.Context, mirro
 				logger.Error("Error occurred while updating the status of mirrorpeer", "error", statusErr, "MirrorPeer", mirrorPeer.Name)
 				return ctrl.Result{Requeue: true}, nil
 			}
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: true}, nil
 		}
 	} else {
 		// Sync mode status update, same flow as async but for s3 profile


### PR DESCRIPTION
Restricting to the fetching of cephFSID for when the MirrorPeer is not for StorageClients
Requeue if MirrorPeer is in Phase: ExchangingSecret