### PR TITLE
Set Mirroring field to false than setting it to nil

### DIFF
--- a/addons/agent_mirrorpeer_controller.go
+++ b/addons/agent_mirrorpeer_controller.go
@@ -417,11 +417,12 @@ func (r *MirrorPeerReconciler) toggleMirroring(ctx context.Context, storageClust
 		return err
 	}
 
+	if sc.Spec.Mirroring == nil {
+		sc.Spec.Mirroring = &ocsv1.MirroringSpec{}
+	}
+
 	// Determine if mirroring should be enabled or disabled
 	if enabled {
-		if sc.Spec.Mirroring == nil {
-			sc.Spec.Mirroring = &ocsv1.MirroringSpec{}
-		}
 		oppPeers := getOppositePeerRefs(mp, r.SpokeClusterName)
 		if hasRequiredSecret(sc.Spec.Mirroring.PeerSecretNames, oppPeers) {
 			sc.Spec.Mirroring.Enabled = true
@@ -430,7 +431,7 @@ func (r *MirrorPeerReconciler) toggleMirroring(ctx context.Context, storageClust
 			return fmt.Errorf("StorageCluster %q does not have required PeerSecrets", storageClusterName)
 		}
 	} else {
-		sc.Spec.Mirroring = nil
+		sc.Spec.Mirroring.Enabled = false
 		r.Logger.Info("Mirroring disabled on StorageCluster", "storageClusterName", storageClusterName)
 	}
 

--- a/addons/agent_mirrorpeer_controller_test.go
+++ b/addons/agent_mirrorpeer_controller_test.go
@@ -246,7 +246,7 @@ func TestDisableMirroring(t *testing.T) {
 			t.Error("failed to get storage cluster", err)
 		}
 
-		if sc.Spec.Mirroring != nil {
+		if sc.Spec.Mirroring.Enabled {
 			t.Error("failed to disable mirroring")
 		}
 	}


### PR DESCRIPTION
https://github.com/red-hat-storage/ocs-operator/blob/d62b2a2b1f5663b5a11ff88c9b7a830a298ca071/controllers/storagecluster/cephblockpools.go#L97

OCS operator does not check if cephblockpool's mirroring is enabled when mirroring field in the StorageCluster spec is set to nil. 

Hence setting it nil from here, causes the cephblockpool to remain in true state.

This PR fixes that and explicitly sets the Mirroring spec to be `false` in StorageCluster