### PR TITLE
Fix the length of generated OBC bucket name

### DIFF
--- a/controllers/utils/hash.go
+++ b/controllers/utils/hash.go
@@ -77,7 +77,7 @@ func GenerateUniqueIdForMirrorPeer(mirrorPeer multiclusterv1alpha1.MirrorPeer, h
 		checksum = sha1.Sum([]byte(peerAccumulator))
 	}
 	// truncate to bucketGenerateName + "-" + first 12 (out of 20) byte representations of sha1 checksum
-	return hex.EncodeToString(checksum[:])[0 : len(BucketGenerateName)+1+12]
+	return hex.EncodeToString(checksum[:])
 }
 
 func GetKey(clusterName, clientName string) string {

--- a/controllers/utils/s3.go
+++ b/controllers/utils/s3.go
@@ -53,7 +53,7 @@ func GetEnv(key, defaultValue string) string {
 func GenerateBucketName(mirrorPeer multiclusterv1alpha1.MirrorPeer, hasStorageClientRef bool) string {
 	mirrorPeerId := GenerateUniqueIdForMirrorPeer(mirrorPeer, hasStorageClientRef)
 	bucketGenerateName := BucketGenerateName
-	return fmt.Sprintf("%s-%s", bucketGenerateName, mirrorPeerId)
+	return fmt.Sprintf("%s-%s", bucketGenerateName, mirrorPeerId)[0 : len(BucketGenerateName)+1+12]
 }
 
 func CreateOrUpdateObjectBucketClaim(ctx context.Context, c client.Client, bucketName, bucketNamespace string, annotations map[string]string) (controllerutil.OperationResult, error) {


### PR DESCRIPTION
To fix a bug where the length of the generated bucket name is larger than what is required