### PR TITLE
feat: Add StorageID field to secrets and use it for replication ID

### DIFF
--- a/addons/agent_mirrorpeer_controller_test.go
+++ b/addons/agent_mirrorpeer_controller_test.go
@@ -85,8 +85,9 @@ storageSystemName: test-storagecluster-storagesystem
 	}
 
 	secretData = map[string][]byte{
-		"token":   []byte("eyJmc2lkIjoiMzU2NjZlNGMtZTljMC00ZmE3LWE3MWEtMmIwNTJiZjUxOTFhIiwiY2xpZW50X2lkIjoicmJkLW1pcnJvci1wZWVyIiwia2V5IjoiQVFDZVkwNWlYUmtsTVJBQU95b3I3ZTZPL3MrcTlzRnZWcVpVaHc9PSIsIm1vbl9ob3N0IjoiMTcyLjMxLjE2NS4yMjg6Njc4OSwxNzIuMzEuMTkxLjE0MDo2Nzg5LDE3Mi4zMS44LjQ0OjY3ODkiLCJuYW1lc3BhY2UiOiJvcGVuc2hpZnQtc3RvcmFnZSJ9"),
-		"cluster": []byte(fmt.Sprintf("%s-cephcluster", storageClusterName)),
+		"token":      []byte("eyJmc2lkIjoiMzU2NjZlNGMtZTljMC00ZmE3LWE3MWEtMmIwNTJiZjUxOTFhIiwiY2xpZW50X2lkIjoicmJkLW1pcnJvci1wZWVyIiwia2V5IjoiQVFDZVkwNWlYUmtsTVJBQU95b3I3ZTZPL3MrcTlzRnZWcVpVaHc9PSIsIm1vbl9ob3N0IjoiMTcyLjMxLjE2NS4yMjg6Njc4OSwxNzIuMzEuMTkxLjE0MDo2Nzg5LDE3Mi4zMS44LjQ0OjY3ODkiLCJuYW1lc3BhY2UiOiJvcGVuc2hpZnQtc3RvcmFnZSJ9"),
+		"cluster":    []byte(fmt.Sprintf("%s-cephcluster", storageClusterName)),
+		"storage_id": []byte(`{"cephfs":"f9708852fe4cf1f4d5de7e525f1b0aba","rbd":"dcd70114947d0bb1f6b96f0dd6a9aaca"}`),
 	}
 	// Create secret cluster-peer-token
 	clusterPeerToken = corev1.Secret{

--- a/addons/setup/tokenexchange-manifests/spoke_clusterrole.yaml
+++ b/addons/setup/tokenexchange-manifests/spoke_clusterrole.yaml
@@ -23,7 +23,7 @@ rules:
   verbs: ["get", "list", "watch", "update"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
-  verbs: ["get","list","update"]
+  verbs: ["get","list","update", "watch"]
 - apiGroups: ["submariner.io"]
   resources: ["submariners"]
   verbs: ["get"]

--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -121,10 +121,11 @@ func getFakeDRPolicyReconciler(drpolicy *ramenv1alpha1.DRPolicy, mp *multicluste
 			Namespace: cName1,
 		},
 		Data: map[string][]byte{
-			"namespace":            []byte("openshift-storage"),
-			"secret-data":          []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`),
-			"secret-origin":        []byte("rook"),
-			"storage-cluster-name": []byte("ocs-storagecluster"),
+			"namespace":              []byte("openshift-storage"),
+			"secret-data":            []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`),
+			"secret-origin":          []byte("rook"),
+			"storage-cluster-name":   []byte("ocs-storagecluster"),
+			utils.SecretStorageIDKey: []byte("{\"cephfs\":\"f9708852fe4cf1f4d5de7e525f1b0aba\",\"rbd\":\"dcd70114947d0bb1f6b96f0dd6a9aaca\"}"),
 		},
 		Type: "multicluster.odf.openshift.io/secret-type",
 	}
@@ -135,10 +136,11 @@ func getFakeDRPolicyReconciler(drpolicy *ramenv1alpha1.DRPolicy, mp *multicluste
 			Namespace: cName2,
 		},
 		Data: map[string][]byte{
-			"namespace":            []byte("openshift-storage"),
-			"secret-data":          []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`),
-			"secret-origin":        []byte("rook"),
-			"storage-cluster-name": []byte("ocs-storagecluster"),
+			"namespace":              []byte("openshift-storage"),
+			"secret-data":            []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`),
+			"secret-origin":          []byte("rook"),
+			"storage-cluster-name":   []byte("ocs-storagecluster"),
+			utils.SecretStorageIDKey: []byte("{\"cephfs\":\"f9708852fe4cf1f4d5de7e525f1b0aba\",\"rbd\":\"dcd70114947d0bb1f6b96f0dd6a9aaca\"}"),
 		},
 		Type: "multicluster.odf.openshift.io/secret-type",
 	}

--- a/controllers/named_peerref_with_data.go
+++ b/controllers/named_peerref_with_data.go
@@ -23,6 +23,7 @@ type NamedPeerRefWithSecretData struct {
 	Name         string
 	Data         []byte
 	SecretOrigin string
+	StorageID    string
 }
 
 // NewNamedPeerRefWithSecretData creates a new PeerRef instance which has the source Name and Data details
@@ -34,6 +35,7 @@ func NewNamedPeerRefWithSecretData(secret *corev1.Secret, peerRef multiclusterv1
 		Data:         secret.Data[utils.SecretDataKey],
 		PeerRef:      peerRef,
 		SecretOrigin: string(secret.Data[utils.SecretOriginKey]),
+		StorageID:    string(secret.Data[utils.SecretStorageIDKey]),
 	}
 	return &nPeerRef
 }
@@ -59,9 +61,9 @@ func (nPR *NamedPeerRefWithSecretData) GenerateSecret(secretLabelType utils.Secr
 	}
 	var retSecret *corev1.Secret
 	if secretLabelType == utils.DestinationLabel {
-		retSecret = utils.CreateDestinationSecret(secretNamespacedName, storageClusterNamespacedName, nPR.Data, nPR.SecretOrigin)
+		retSecret = utils.CreateDestinationSecret(secretNamespacedName, storageClusterNamespacedName, nPR.Data, nPR.SecretOrigin, nPR.StorageID)
 	} else if secretLabelType == utils.SourceLabel {
-		retSecret = utils.CreateSourceSecret(secretNamespacedName, storageClusterNamespacedName, nPR.Data, nPR.SecretOrigin)
+		retSecret = utils.CreateSourceSecret(secretNamespacedName, storageClusterNamespacedName, nPR.Data, nPR.SecretOrigin, nPR.StorageID)
 	}
 
 	return retSecret

--- a/controllers/utils/hash.go
+++ b/controllers/utils/hash.go
@@ -45,21 +45,15 @@ func CreateUniqueSecretNameForClient(providerKey, clientKey1, clientKey2 string)
 	return CreateUniqueName(providerKey, clientKey1, clientKey2)[0:39]
 }
 
-func CreateUniqueReplicationId(clusterFSIDs map[string]string) (string, error) {
-	var fsids []string
-	for _, v := range clusterFSIDs {
-		if v != "" {
-			fsids = append(fsids, v)
-		}
+func CreateUniqueReplicationId(storageIds ...string) (string, error) {
+	if len(storageIds) < 2 {
+		return "", fmt.Errorf("replicationID can not be generated due to missing cluster StorageIds")
 	}
 
-	if len(fsids) < 2 {
-		return "", fmt.Errorf("replicationID can not be generated due to missing cluster FSID")
-	}
+	sort.Strings(storageIds)
 
-	// To ensure reliability of hash generation
-	sort.Strings(fsids)
-	return CreateUniqueName(fsids...)[0:39], nil
+	id := CalculateMD5Hash(storageIds)
+	return id, nil
 }
 
 func GenerateUniqueIdForMirrorPeer(mirrorPeer multiclusterv1alpha1.MirrorPeer, hasStorageClientRef bool) string {

--- a/controllers/utils/hash_test.go
+++ b/controllers/utils/hash_test.go
@@ -24,63 +24,87 @@ func TestFnvHashTest(t *testing.T) {
 
 func TestCreateUniqueReplicationId(t *testing.T) {
 	type args struct {
-		fsids map[string]string
+		storageIds map[string]string
 	}
 	tests := []struct {
 		name    string
 		args    args
 		want    string
-		wantErr bool
+		wantErr string // Changed to string to check error message
 	}{
 		{
 			name: "Case 1: Both FSID available",
 			args: args{
-				fsids: map[string]string{
+				storageIds: map[string]string{
 					"c1": "7e252ee3-abd9-4c54-a4ff-a2fdce8931a0",
 					"c2": "aacfbd7e-5ced-42a5-bdc2-483fcbe5a29d",
 				},
 			},
-			want:    "a99df9fc6c52c7ef44222ab38657a0b15628a14",
-			wantErr: false,
+			want:    "a52e5dd4473c6fedbcf084d27a84c9bb",
+			wantErr: "",
 		},
 		{
-			name: "Case 2: FSID for C1 is available",
+			name: "Case 2: FSID for C1 is available, C2 empty",
 			args: args{
-				fsids: map[string]string{
+				storageIds: map[string]string{
 					"c1": "7e252ee3-abd9-4c54-a4ff-a2fdce8931a0",
 					"c2": "",
 				},
 			},
 			want:    "",
-			wantErr: true,
+			wantErr: "replicationID can not be generated due to missing cluster StorageIds",
 		},
 		{
-			name: "Case 3: FSID for C2 is available",
+			name: "Case 3: FSID for C2 is available, C1 empty",
 			args: args{
-				fsids: map[string]string{
+				storageIds: map[string]string{
 					"c1": "",
 					"c2": "aacfbd7e-5ced-42a5-bdc2-483fcbe5a29d",
 				},
 			},
 			want:    "",
-			wantErr: true,
+			wantErr: "replicationID can not be generated due to missing cluster StorageIds",
 		},
 		{
 			name: "Case 4: Both FSID unavailable",
 			args: args{
-				fsids: map[string]string{
+				storageIds: map[string]string{
 					"c1": "",
 					"c2": "",
 				},
 			},
 			want:    "",
-			wantErr: true,
+			wantErr: "replicationID can not be generated due to missing cluster StorageIds",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := CreateUniqueReplicationId(tt.args.fsids)
-			if ((err != nil) != tt.wantErr) || got != tt.want {
+			var ids []string
+			for _, id := range []string{tt.args.storageIds["c1"], tt.args.storageIds["c2"]} {
+				if id != "" {
+					ids = append(ids, id)
+				}
+			}
+
+			got, err := CreateUniqueReplicationId(ids...)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Errorf("CreateUniqueReplicationId() expected error = %v, got no error", tt.wantErr)
+					return
+				}
+				if err.Error() != tt.wantErr {
+					t.Errorf("CreateUniqueReplicationId() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("CreateUniqueReplicationId() unexpected error = %v", err)
+				return
+			}
+
+			if got != tt.want {
 				t.Errorf("CreateUniqueReplicationId() = %v, want %v", got, tt.want)
 			}
 		})

--- a/tests/integration/mirrorpeer_status_test.go
+++ b/tests/integration/mirrorpeer_status_test.go
@@ -196,7 +196,7 @@ var _ = Describe("MirrorPeer Status Tests", func() {
 				Namespace: pr1.StorageClusterRef.Namespace,
 			}
 
-			sec1 := utils.CreateSourceSecret(secretNN1, storageClusterNN1, []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`), utils.OriginMap["RookOrigin"])
+			sec1 := utils.CreateSourceSecret(secretNN1, storageClusterNN1, []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`), utils.OriginMap["RookOrigin"], `{"cephfs":"f9708852fe4cf1f4d5de7e525f1b0aba","rbd":"dcd70114947d0bb1f6b96f0dd6a9aaca"}`)
 
 			secretNN2 := types.NamespacedName{
 				Name:      utils.GetSecretNameByPeerRef(pr2),
@@ -208,7 +208,7 @@ var _ = Describe("MirrorPeer Status Tests", func() {
 				Namespace: pr2.StorageClusterRef.Namespace,
 			}
 
-			sec2 := utils.CreateSourceSecret(secretNN2, storageClusterNN2, []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`), utils.OriginMap["RookOrigin"])
+			sec2 := utils.CreateSourceSecret(secretNN2, storageClusterNN2, []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`), utils.OriginMap["RookOrigin"], `{"cephfs":"f9708852fe4cf1f4d5de7e525f1b0aba","rbd":"dcd70114947d0bb1f6b96f0dd6a9aaca"}`)
 
 			s3sec1 := GetFakeS3SecretForPeerRef(pr1)
 			s3sec2 := GetFakeS3SecretForPeerRef(pr2)

--- a/tests/integration/mirrorpeersecret_controller_test.go
+++ b/tests/integration/mirrorpeersecret_controller_test.go
@@ -92,7 +92,7 @@ func (mppp MirrorPeerPlusPlus) GetDummySourceSecrets(prefixName string) []corev1
 			Name:      eachPR.StorageClusterRef.Name,
 			Namespace: eachPR.StorageClusterRef.Namespace,
 		}
-		sourceSecret := utils.CreateSourceSecret(secretNN, storageClusterNN, []byte("MySecretData1234"), utils.OriginMap["RookOrigin"])
+		sourceSecret := utils.CreateSourceSecret(secretNN, storageClusterNN, []byte("MySecretData1234"), utils.OriginMap["RookOrigin"], `{"cephfs":"f9708852fe4cf1f4d5de7e525f1b0aba","rbd":"dcd70114947d0bb1f6b96f0dd6a9aaca"}`)
 		sourceSecrets = append(sourceSecrets, *sourceSecret)
 	}
 	return sourceSecrets
@@ -465,7 +465,7 @@ var _ = Describe("MirrorPeerSecret Controller", func() {
 				}
 				sourceNN := types.NamespacedName{Name: "source-3", Namespace: newPeer.ClusterName}
 				storageClusterNN := types.NamespacedName{Name: newPeer.StorageClusterRef.Name, Namespace: newPeer.StorageClusterRef.Namespace}
-				newSource := utils.CreateSourceSecret(sourceNN, storageClusterNN, []byte("new-secret-3"), utils.OriginMap["RookOrigin"])
+				newSource := utils.CreateSourceSecret(sourceNN, storageClusterNN, []byte("new-secret-3"), utils.OriginMap["RookOrigin"], `{"cephfs":"f9708852fe4cf1f4d5de7e525f1b0aba","rbd":"dcd70114947d0bb1f6b96f0dd6a9aaca"}`)
 				err = k8sClient.Create(ctx, newSource)
 				Expect(err).To(BeNil())
 				err = k8sClient.Update(ctx, &mirrorPR)

--- a/tests/integration/ramen_test.go
+++ b/tests/integration/ramen_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Ramen Resource Tests", func() {
 		Namespace: pr1.StorageClusterRef.Namespace,
 	}
 
-	sec1 := utils.CreateSourceSecret(secretNN1, storageClusterNN1, []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`), utils.OriginMap["RookOrigin"])
+	sec1 := utils.CreateSourceSecret(secretNN1, storageClusterNN1, []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`), utils.OriginMap["RookOrigin"], `{"cephfs":"f9708852fe4cf1f4d5de7e525f1b0aba","rbd":"dcd70114947d0bb1f6b96f0dd6a9aaca"}`)
 
 	secretNN2 := types.NamespacedName{
 		Name:      utils.GetSecretNameByPeerRef(pr2),
@@ -106,7 +106,7 @@ var _ = Describe("Ramen Resource Tests", func() {
 		Namespace: pr2.StorageClusterRef.Namespace,
 	}
 
-	sec2 := utils.CreateSourceSecret(secretNN2, storageClusterNN2, []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`), utils.OriginMap["RookOrigin"])
+	sec2 := utils.CreateSourceSecret(secretNN2, storageClusterNN2, []byte(`{"cluster":"b2NzLXN0b3JhZ2VjbHVzdGVyLWNlcGhjbHVzdGVy","token":"ZXlKbWMybGtJam9pWXpSak56SmpNRE10WXpCbFlpMDBZMlppTFRnME16RXRNekExTmpZME16UmxZV1ZqSWl3aVkyeHBaVzUwWDJsa0lqb2ljbUprTFcxcGNuSnZjaTF3WldWeUlpd2lhMlY1SWpvaVFWRkVkbGxyTldrM04xbG9TMEpCUVZZM2NFZHlVVXBrU1VvelJtZGpjVWxGVUZWS0wzYzlQU0lzSW0xdmJsOW9iM04wSWpvaU1UY3lMak13TGpFd01TNHlORGs2TmpjNE9Td3hOekl1TXpBdU1UZ3pMakU1TURvMk56ZzVMREUzTWk0ek1DNHlNak11TWpFd09qWTNPRGtpTENKdVlXMWxjM0JoWTJVaU9pSnZjR1Z1YzJocFpuUXRjM1J2Y21GblpTSjk="}`), utils.OriginMap["RookOrigin"], `{"cephfs":"f9708852fe4cf1f4d5de7e525f1b0aba","rbd":"dcd70114947d0bb1f6b96f0dd6a9aaca"}`)
 
 	s3sec1 := GetFakeS3SecretForPeerRef(pr1)
 	s3sec2 := GetFakeS3SecretForPeerRef(pr2)


### PR DESCRIPTION
Adds a new StorageID field to blue/green secrets and updates the replication ID generation to use storage IDs instead of FSIDs. Key changes:

- Add storage_id field to all secret types (blue/green/hub)
- Update secret handlers to properly propagate storage IDs between secrets
- Add helper functions to get storage IDs from different secret types
- Update replication ID generation to use storage IDs instead of FSIDs
- Add tests for storage ID handling and verification
- Update labelCephClusters to use storage IDs for replication ID