### PR TITLE
use same S3 naming scheme for internal and provider mode

### DIFF
--- a/addons/agent_mirrorpeer_controller.go
+++ b/addons/agent_mirrorpeer_controller.go
@@ -381,7 +381,7 @@ func (r *MirrorPeerReconciler) getSecretNameByType(clusterType utils.ClusterType
 
 func (r *MirrorPeerReconciler) createS3(ctx context.Context, mirrorPeer multiclusterv1alpha1.MirrorPeer, scNamespace string, hasStorageClientRef bool) error {
 	bucketNamespace := utils.GetEnv("ODR_NAMESPACE", scNamespace)
-	bucketName := utils.GenerateBucketName(mirrorPeer, hasStorageClientRef)
+	bucketName := utils.GenerateBucketName(mirrorPeer)
 	annotations := map[string]string{
 		utils.MirrorPeerNameAnnotationKey: mirrorPeer.Name,
 	}
@@ -587,7 +587,7 @@ func (r *MirrorPeerReconciler) deleteGreenSecret(ctx context.Context, spokeClust
 // deleteS3 deletes the S3 bucket in the storage cluster namespace, each new mirrorpeer generates
 // a new bucket, so we do not need to check if the bucket is being used by another mirrorpeer
 func (r *MirrorPeerReconciler) deleteS3(ctx context.Context, mirrorPeer multiclusterv1alpha1.MirrorPeer, scNamespace string) error {
-	bucketName := utils.GenerateBucketName(mirrorPeer, false)
+	bucketName := utils.GenerateBucketName(mirrorPeer)
 	bucketNamespace := utils.GetEnv("ODR_NAMESPACE", scNamespace)
 	noobaaOBC, err := utils.GetObjectBucketClaim(ctx, r.SpokeClient, bucketName, bucketNamespace)
 	if err != nil {

--- a/addons/agent_mirrorpeer_controller_test.go
+++ b/addons/agent_mirrorpeer_controller_test.go
@@ -522,7 +522,7 @@ func TestDeleteGreenSecret(t *testing.T) {
 }
 
 func TestDeleteS3(t *testing.T) {
-	bucketName := utils.GenerateBucketName(mirrorPeer, false)
+	bucketName := utils.GenerateBucketName(mirrorPeer)
 	ctx := context.TODO()
 	scheme := mgrScheme
 	fakeHubClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&mirrorpeer1).Build()

--- a/controllers/utils/hash.go
+++ b/controllers/utils/hash.go
@@ -56,22 +56,13 @@ func CreateUniqueReplicationId(storageIds ...string) (string, error) {
 	return id, nil
 }
 
-func GenerateUniqueIdForMirrorPeer(mirrorPeer multiclusterv1alpha1.MirrorPeer, hasStorageClientRef bool) string {
+func GenerateUniqueIdForMirrorPeer(mirrorPeer multiclusterv1alpha1.MirrorPeer) string {
 	var checksum [20]byte
-	if hasStorageClientRef {
-		var peerAccumulator []string
-		for _, peer := range mirrorPeer.Spec.Items {
-			peerAccumulator = append(peerAccumulator, GetKey(peer.ClusterName, peer.StorageClusterRef.Name))
-		}
-		sort.Strings(peerAccumulator)
-		checksum = sha1.Sum([]byte(strings.Join(peerAccumulator, "-")))
-	} else {
-		var peerAccumulator string
-		for _, peer := range mirrorPeer.Spec.Items {
-			peerAccumulator += peer.ClusterName
-		}
-		checksum = sha1.Sum([]byte(peerAccumulator))
+	var peerAccumulator string
+	for _, peer := range mirrorPeer.Spec.Items {
+		peerAccumulator += peer.ClusterName
 	}
+	checksum = sha1.Sum([]byte(peerAccumulator))
 	// truncate to bucketGenerateName + "-" + first 12 (out of 20) byte representations of sha1 checksum
 	return hex.EncodeToString(checksum[:])
 }

--- a/controllers/utils/peer_ref_test.go
+++ b/controllers/utils/peer_ref_test.go
@@ -1,0 +1,109 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetPeerRefForProviderCluster(t *testing.T) {
+	err := os.Setenv("POD_NAMESPACE", "openshift-storage")
+	assert.NoError(t, err)
+
+	mgrScheme := runtime.NewScheme()
+	assert.NoError(t, clientgoscheme.AddToScheme(mgrScheme))
+	assert.NoError(t, multiclusterv1alpha1.AddToScheme(mgrScheme))
+	assert.NoError(t, clusterv1.AddToScheme(mgrScheme))
+
+	mirrorpeer := &multiclusterv1alpha1.MirrorPeer{
+		Spec: multiclusterv1alpha1.MirrorPeerSpec{
+			Items: []multiclusterv1alpha1.PeerRef{
+				{
+					ClusterName: "cluster1",
+					StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
+						Name:      "ocs-storagecluster",
+						Namespace: "openshift-storage",
+					},
+				},
+				{
+					ClusterName: "cluster2",
+					StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
+						Name:      "ocs-storagecluster",
+						Namespace: "openshift-storage",
+					},
+				},
+			},
+		},
+	}
+
+	obj := []runtime.Object{
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ODFInfoConfigMapName,
+				Namespace: "openshift-storage",
+			},
+			Data: map[string]string{
+				"openshift-storage_ocs-storagecluster.config.yaml": `
+version: 4.18.0-126.stable
+deploymentType: internal
+clients:
+- name: ocs-storagecluster
+  clusterId: fb64afb3-d933-42a9-a25b-e119652a8db6
+  clientId: 85331431-11c3-47ef-bd83-f5ff6d49be8c
+- name: ocs-storagecluster
+  clusterId: 4524a27b-03ab-4f35-9441-b51e1267a10b
+  clientId: 85331431-11c3-47ef-bd83-f5ff6d49be8c
+storageCluster:
+  namespacedName:
+    namespace: openshift-storage
+    name: ocs-storagecluster
+  storageProviderEndpoint: 172.30.63.56:50051
+  cephClusterFSID: 747a4fb7-e130-4f25-bb4d-c9ceb8ef5764
+  storageClusterUID: 4524a27b-03ab-4f35-9441-b51e1267a10b
+  annotations:
+    ocs.openshift.io/api-server-exported-address: baremetal-1.ocs-provider-server.openshift-storage.svc.clusterset.local:50051
+    ocs.openshift.io/deployment-mode: provider
+    uninstall.ocs.openshift.io/cleanup-policy: delete
+    uninstall.ocs.openshift.io/mode: graceful
+storageSystemName: ocs-storagecluster-storagesystem
+`,
+			},
+		},
+		mirrorpeer,
+		&clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster1",
+				Labels: map[string]string{
+					"clusterID": "fb64afb3-d933-42a9-a25b-e119652a8db6",
+				},
+			},
+		},
+		&clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster2",
+				Labels: map[string]string{
+					"clusterID": "4524a27b-03ab-4f35-9441-b51e1267a10b",
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(mgrScheme).WithRuntimeObjects(obj...).Build()
+	refList, err := GetPeerRefForProviderCluster(context.TODO(), c, c, mirrorpeer)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(refList))
+	assert.Equal(t, "cluster1", refList[0].ClusterName)
+	assert.NotEqual(t, "cluster2", refList[0].ClusterName)
+	assert.Equal(t, "cluster2", refList[1].ClusterName)
+	assert.NotEqual(t, "cluster1", refList[1].ClusterName)
+	err = os.Unsetenv("POD_NAMESPACE")
+	assert.NoError(t, err)
+}

--- a/controllers/utils/s3.go
+++ b/controllers/utils/s3.go
@@ -40,6 +40,7 @@ func GetCurrentStorageClusterRef(mp *multiclusterv1alpha1.MirrorPeer, spokeClust
 			return &v.StorageClusterRef, nil
 		}
 	}
+
 	return nil, fmt.Errorf("StorageClusterRef for cluster %s under mirrorpeer %s not found", spokeClusterName, mp.Name)
 }
 
@@ -50,10 +51,9 @@ func GetEnv(key, defaultValue string) string {
 	return defaultValue
 }
 
-func GenerateBucketName(mirrorPeer multiclusterv1alpha1.MirrorPeer, hasStorageClientRef bool) string {
-	mirrorPeerId := GenerateUniqueIdForMirrorPeer(mirrorPeer, hasStorageClientRef)
-	bucketGenerateName := BucketGenerateName
-	return fmt.Sprintf("%s-%s", bucketGenerateName, mirrorPeerId)[0 : len(BucketGenerateName)+1+12]
+func GenerateBucketName(mirrorPeer multiclusterv1alpha1.MirrorPeer) string {
+	mirrorPeerId := GenerateUniqueIdForMirrorPeer(mirrorPeer)
+	return fmt.Sprintf("%s-%s", BucketGenerateName, mirrorPeerId)[0 : len(BucketGenerateName)+1+12]
 }
 
 func CreateOrUpdateObjectBucketClaim(ctx context.Context, c client.Client, bucketName, bucketNamespace string, annotations map[string]string) (controllerutil.OperationResult, error) {

--- a/controllers/utils/s3_test.go
+++ b/controllers/utils/s3_test.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"testing"
+
+	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateBucketName(t *testing.T) {
+	mirrorPeer := multiclusterv1alpha1.MirrorPeer{
+		Spec: multiclusterv1alpha1.MirrorPeerSpec{
+			Items: []multiclusterv1alpha1.PeerRef{
+				{
+					ClusterName: "cluster1",
+					StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
+						Name:      "ocs-storagecluster",
+						Namespace: "openshift-storage",
+					},
+				},
+				{
+					ClusterName: "cluster2",
+					StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
+						Name:      "ocs-storagecluster",
+						Namespace: "openshift-storage",
+					},
+				},
+			},
+		},
+	}
+	bucket := GenerateBucketName(mirrorPeer)
+	assert.Equal(t, "odrbucket-b1b922184baf", bucket)
+
+	mirrorPeer = multiclusterv1alpha1.MirrorPeer{
+		Spec: multiclusterv1alpha1.MirrorPeerSpec{
+			Items: []multiclusterv1alpha1.PeerRef{
+				{
+					ClusterName: "cluster1",
+					StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
+						Name: "ocs-storagecluster",
+					},
+				},
+				{
+					ClusterName: "cluster2",
+					StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
+						Name: "ocs-storagecluster",
+					},
+				},
+			},
+		},
+	}
+	bucket = GenerateBucketName(mirrorPeer)
+	assert.Equal(t, "odrbucket-b1b922184baf", bucket)
+
+	mirrorPeer = multiclusterv1alpha1.MirrorPeer{
+		Spec: multiclusterv1alpha1.MirrorPeerSpec{
+			Items: []multiclusterv1alpha1.PeerRef{
+				{
+					ClusterName: "cluster3",
+					StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
+						Name: "ocs-storagecluster",
+					},
+				},
+				{
+					ClusterName: "cluster4",
+					StorageClusterRef: multiclusterv1alpha1.StorageClusterRef{
+						Name: "ocs-storagecluster",
+					},
+				},
+			},
+		},
+	}
+	bucket = GenerateBucketName(mirrorPeer)
+	assert.Equal(t, "odrbucket-db0233c5db46", bucket)
+}


### PR DESCRIPTION
Using different naming scheme for internal and provider mode could cause issues later on if/when users want to move between modes. So, this commit reverts the special handling for provider mode during OBC name generation, S3 profile name generation and S3 secret name generation for the hub.

This does not address changes required for certain usecases like multiple clients on same cluster.