### PR TITLE
Batch update codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ifeq ($(OPENSHIFT_CI), true)
 else
 	@echo "Running outside OpenShift CI. Ignoring vendor"
 endif
-	make manifests generate fmt vet
+	make manifests generate fmt vet golangci-lint
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./tests/integration/... -v -tags integration -coverprofile integration-cover.out

--- a/addons/agent_mirrorpeer_controller.go
+++ b/addons/agent_mirrorpeer_controller.go
@@ -394,6 +394,7 @@ func (r *MirrorPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Logger.Info("Setting up controller with manager")
 	mpPredicate := utils.ComposePredicates(predicate.GenerationChangedPredicate{}, mirrorPeerSpokeClusterPredicate)
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("agent_mirrorpeer_controller").
 		For(&multiclusterv1alpha1.MirrorPeer{}, builder.WithPredicates(mpPredicate)).
 		WatchesMetadata(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(tokenToMirrorPeerMapFunc), builder.WithPredicates(utils.SourceOrDestinationPredicate)).
 		Complete(r)

--- a/addons/agent_mirrorpeer_controller.go
+++ b/addons/agent_mirrorpeer_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
@@ -50,6 +49,8 @@ type MirrorPeerReconciler struct {
 	SpokeClusterName     string
 	OdfOperatorNamespace string
 	Logger               *slog.Logger
+
+	testEnvFile string
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -82,7 +83,8 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	var scr *multiclusterv1alpha1.StorageClusterRef
 	if hasStorageClientRef {
-		currentNamespace := os.Getenv("POD_NAMESPACE")
+		currentNamespace := utils.GetEnv("POD_NAMESPACE", r.testEnvFile)
+
 		sc, err := utils.GetStorageClusterFromCurrentNamespace(ctx, r.SpokeClient, currentNamespace)
 		if err != nil {
 			logger.Error("Failed to fetch StorageCluster for given namespace", "Namespace", currentNamespace)
@@ -320,7 +322,7 @@ func (r *MirrorPeerReconciler) fetchClusterStorageIds(ctx context.Context, mp *m
 }
 
 func (r *MirrorPeerReconciler) createS3(ctx context.Context, mirrorPeer multiclusterv1alpha1.MirrorPeer, scNamespace string, hasStorageClientRef bool) error {
-	bucketNamespace := utils.GetEnv("ODR_NAMESPACE", scNamespace)
+	bucketNamespace := utils.GetEnvOrDefault("ODR_NAMESPACE", scNamespace, r.testEnvFile)
 	bucketName := utils.GenerateBucketName(mirrorPeer)
 	annotations := map[string]string{
 		utils.MirrorPeerNameAnnotationKey: mirrorPeer.Name,
@@ -404,7 +406,7 @@ func (r *MirrorPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // a new bucket, so we do not need to check if the bucket is being used by another mirrorpeer
 func (r *MirrorPeerReconciler) deleteS3(ctx context.Context, mirrorPeer multiclusterv1alpha1.MirrorPeer, scNamespace string) error {
 	bucketName := utils.GenerateBucketName(mirrorPeer)
-	bucketNamespace := utils.GetEnv("ODR_NAMESPACE", scNamespace)
+	bucketNamespace := utils.GetEnvOrDefault("ODR_NAMESPACE", scNamespace, r.testEnvFile)
 	noobaaOBC, err := utils.GetObjectBucketClaim(ctx, r.SpokeClient, bucketName, bucketNamespace)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/addons/agent_mirrorpeer_controller.go
+++ b/addons/agent_mirrorpeer_controller.go
@@ -50,7 +50,8 @@ type MirrorPeerReconciler struct {
 	OdfOperatorNamespace string
 	Logger               *slog.Logger
 
-	testEnvFile string
+	testEnvFile      string
+	currentNamespace string
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -83,11 +84,9 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	var scr *multiclusterv1alpha1.StorageClusterRef
 	if hasStorageClientRef {
-		currentNamespace := utils.GetEnv("POD_NAMESPACE", r.testEnvFile)
-
-		sc, err := utils.GetStorageClusterFromCurrentNamespace(ctx, r.SpokeClient, currentNamespace)
+		sc, err := utils.GetStorageClusterFromCurrentNamespace(ctx, r.SpokeClient, r.currentNamespace)
 		if err != nil {
-			logger.Error("Failed to fetch StorageCluster for given namespace", "Namespace", currentNamespace)
+			logger.Error("Failed to fetch StorageCluster for given namespace", "Namespace", r.currentNamespace)
 			return ctrl.Result{}, err
 		}
 		scr = &multiclusterv1alpha1.StorageClusterRef{

--- a/addons/manager.go
+++ b/addons/manager.go
@@ -135,6 +135,8 @@ func (o *AddonAgentOptions) RunAgent(ctx context.Context) {
 }
 
 func runHubManager(ctx context.Context, options AddonAgentOptions, logger *slog.Logger) {
+	currentNamespace := utils.GetEnv("POD_NAMESPACE", options.testEnvFile)
+
 	hubConfig, err := utils.GetClientConfig(options.HubKubeconfigFile)
 	if err != nil {
 		logger.Error("Failed to get kubeconfig", "error", err)
@@ -179,6 +181,7 @@ func runHubManager(ctx context.Context, options AddonAgentOptions, logger *slog.
 		OdfOperatorNamespace: options.OdfOperatorNamespace,
 		Logger:               logger.With("controller", "MirrorPeerReconciler"),
 		testEnvFile:          options.testEnvFile,
+		currentNamespace:     currentNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error("Failed to create MirrorPeer controller", "controller", "MirrorPeer", "error", err)
 		os.Exit(1)
@@ -192,6 +195,8 @@ func runHubManager(ctx context.Context, options AddonAgentOptions, logger *slog.
 }
 
 func runSpokeManager(ctx context.Context, options AddonAgentOptions, logger *slog.Logger) {
+	currentNamespace := utils.GetEnv("POD_NAMESPACE", options.testEnvFile)
+
 	spokeKubeConfig, err := utils.GetClientConfig(options.KubeconfigFile)
 	if err != nil {
 		logger.Error("Failed to get kubeconfig", "error", err)
@@ -211,8 +216,6 @@ func runSpokeManager(ctx context.Context, options AddonAgentOptions, logger *slo
 		logger.Error("Failed to start manager", "error", err)
 		os.Exit(1)
 	}
-
-	currentNamespace := utils.GetEnv("POD_NAMESPACE", options.testEnvFile)
 
 	spokeKubeClient, err := kubernetes.NewForConfig(spokeKubeConfig)
 	if err != nil {
@@ -254,6 +257,7 @@ func runSpokeManager(ctx context.Context, options AddonAgentOptions, logger *slo
 		SpokeClusterName: options.SpokeClusterName,
 		Logger:           logger.With("controller", "S3SecretReconciler"),
 		testEnvFile:      options.testEnvFile,
+		currentNamespace: currentNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error("Failed to create S3Secret controller", "controller", "S3Secret", "error", err)
 		os.Exit(1)

--- a/addons/manager.go
+++ b/addons/manager.go
@@ -63,8 +63,7 @@ func NewAddonAgentCommand() *cobra.Command {
 		Use:   "addons",
 		Short: "Start the addon agents",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx := ctrl.SetupSignalHandler()
-			o.RunAgent(ctx)
+			o.RunAgent(cmd.Context())
 		},
 	}
 

--- a/addons/s3_controller.go
+++ b/addons/s3_controller.go
@@ -3,7 +3,6 @@ package addons
 import (
 	"context"
 	"log/slog"
-	"os"
 	"strings"
 	"time"
 
@@ -27,12 +26,13 @@ type S3SecretReconciler struct {
 	SpokeClient      client.Client
 	SpokeClusterName string
 	Logger           *slog.Logger
+	testEnvFile      string
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *S3SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	isOurOBC := func(obj interface{}) bool {
-		s3MatchString := os.Getenv("S3_EXCHANGE_SOURCE_SECRET_STRING_MATCH")
+		s3MatchString := utils.GetEnv("S3_EXCHANGE_SOURCE_SECRET_STRING_MATCH", r.testEnvFile)
 		if s3MatchString == "" {
 			s3MatchString = utils.BucketGenerateName
 		}

--- a/addons/s3_controller.go
+++ b/addons/s3_controller.go
@@ -26,7 +26,9 @@ type S3SecretReconciler struct {
 	SpokeClient      client.Client
 	SpokeClusterName string
 	Logger           *slog.Logger
+
 	testEnvFile      string
+	currentNamespace string
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"os"
 
@@ -23,4 +25,13 @@ func Execute() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+func ExecuteCommandForTest(ctx context.Context, args []string) (string, error) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args)
+	err := rootCmd.ExecuteContext(ctx)
+	return buf.String(), err
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 var rootCmd = &cobra.Command{
@@ -21,7 +22,8 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	ctx := signals.SetupSignalHandler()
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/controllers/common_controller_utils.go
+++ b/controllers/common_controller_utils.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"reflect"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -268,7 +267,7 @@ func updateRamenHubOperatorConfig(ctx context.Context, rc client.Client, secret 
 	return nil
 }
 
-func createOrUpdateSecretsFromInternalSecret(ctx context.Context, rc client.Client, secret *corev1.Secret, mirrorPeers []multiclusterv1alpha1.MirrorPeer, logger *slog.Logger) error {
+func createOrUpdateSecretsFromInternalSecret(ctx context.Context, rc client.Client, currentNamespace string, secret *corev1.Secret, mirrorPeers []multiclusterv1alpha1.MirrorPeer, logger *slog.Logger) error {
 	logger.Info("Validating internal secret", "SecretName", secret.Name, "Namespace", secret.Namespace)
 
 	if err := utils.ValidateInternalSecret(secret, utils.InternalLabel); err != nil {
@@ -292,7 +291,6 @@ func createOrUpdateSecretsFromInternalSecret(ctx context.Context, rc client.Clie
 			return err
 		}
 
-		currentNamespace := os.Getenv("POD_NAMESPACE")
 		if err := createOrUpdateRamenS3Secret(ctx, rc, secret, data, currentNamespace, logger); err != nil {
 			logger.Error("Failed to create or update Ramen S3 secret", "error", err, "SecretName", secret.Name, "Namespace", currentNamespace)
 			return err

--- a/controllers/common_controller_utils_test.go
+++ b/controllers/common_controller_utils_test.go
@@ -269,9 +269,9 @@ func TestMirrorPeerSecretReconcile(t *testing.T) {
 	for _, c := range cases {
 		os.Setenv("POD_NAMESPACE", c.ramenNamespace)
 		ctx := context.TODO()
-		err := createOrUpdateSecretsFromInternalSecret(ctx, fakeClient, fakeS3InternalSecret(t, TestSourceManagedClusterEast), fakeMirrorPeers(c.manageS3), fakeLogger)
+		err := createOrUpdateSecretsFromInternalSecret(ctx, fakeClient, c.ramenNamespace, fakeS3InternalSecret(t, TestSourceManagedClusterEast), fakeMirrorPeers(c.manageS3), fakeLogger)
 		assert.NoError(t, err)
-		err = createOrUpdateSecretsFromInternalSecret(ctx, fakeClient, fakeS3InternalSecret(t, TestDestinationManagedClusterWest), fakeMirrorPeers(c.manageS3), fakeLogger)
+		err = createOrUpdateSecretsFromInternalSecret(ctx, fakeClient, c.ramenNamespace, fakeS3InternalSecret(t, TestDestinationManagedClusterWest), fakeMirrorPeers(c.manageS3), fakeLogger)
 		assert.NoError(t, err)
 
 		if c.ignoreS3Profile {

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -46,7 +46,8 @@ type DRPolicyReconciler struct {
 	Scheme    *runtime.Scheme
 	Logger    *slog.Logger
 
-	testEnvFile string
+	testEnvFile      string
+	currentNamespace string
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -45,6 +45,8 @@ type DRPolicyReconciler struct {
 	HubClient client.Client
 	Scheme    *runtime.Scheme
 	Logger    *slog.Logger
+
+	testEnvFile string
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -130,7 +130,7 @@ func getFakeDRPolicyReconciler(drpolicy *ramenv1alpha1.DRPolicy, mp *multicluste
 	odfClientInfoConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "odf-client-info",
-			Namespace: os.Getenv("POD_NAMESPACE"),
+			Namespace: utils.GetEnv("POD_NAMESPACE"),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: viewv1beta1.GroupVersion.String(),

--- a/controllers/managedcluster_controller.go
+++ b/controllers/managedcluster_controller.go
@@ -19,8 +19,9 @@ import (
 )
 
 type ManagedClusterReconciler struct {
-	Client client.Client
-	Logger *slog.Logger
+	Client      client.Client
+	Logger      *slog.Logger
+	testEnvFile string
 }
 
 func (r *ManagedClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {

--- a/controllers/managedcluster_controller.go
+++ b/controllers/managedcluster_controller.go
@@ -19,9 +19,10 @@ import (
 )
 
 type ManagedClusterReconciler struct {
-	Client      client.Client
-	Logger      *slog.Logger
-	testEnvFile string
+	Client           client.Client
+	Logger           *slog.Logger
+	testEnvFile      string
+	currentNamespace string
 }
 
 func (r *ManagedClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {

--- a/controllers/managedclusterview_controller.go
+++ b/controllers/managedclusterview_controller.go
@@ -25,9 +25,10 @@ import (
 )
 
 type ManagedClusterViewReconciler struct {
-	Client      client.Client
-	Logger      *slog.Logger
-	testEnvFile string
+	Client           client.Client
+	Logger           *slog.Logger
+	testEnvFile      string
+	currentNamespace string
 }
 
 const (
@@ -98,9 +99,7 @@ func (r *ManagedClusterViewReconciler) Reconcile(ctx context.Context, req reconc
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	operatorNamespace := utils.GetEnv("POD_NAMESPACE", r.testEnvFile)
-
-	if err := createOrUpdateConfigMap(ctx, r.Client, operatorNamespace, managedClusterView, r.Logger); err != nil {
+	if err := createOrUpdateConfigMap(ctx, r.Client, r.currentNamespace, managedClusterView, r.Logger); err != nil {
 		logger.Error("Failed to create or update ConfigMap for ManagedClusterView", "error", err)
 		return ctrl.Result{}, err
 	}

--- a/controllers/managedclusterview_controller.go
+++ b/controllers/managedclusterview_controller.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
@@ -26,8 +25,9 @@ import (
 )
 
 type ManagedClusterViewReconciler struct {
-	Client client.Client
-	Logger *slog.Logger
+	Client      client.Client
+	Logger      *slog.Logger
+	testEnvFile string
 }
 
 const (
@@ -98,7 +98,9 @@ func (r *ManagedClusterViewReconciler) Reconcile(ctx context.Context, req reconc
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err := createOrUpdateConfigMap(ctx, r.Client, managedClusterView, r.Logger); err != nil {
+	operatorNamespace := utils.GetEnv("POD_NAMESPACE", r.testEnvFile)
+
+	if err := createOrUpdateConfigMap(ctx, r.Client, operatorNamespace, managedClusterView, r.Logger); err != nil {
 		logger.Error("Failed to create or update ConfigMap for ManagedClusterView", "error", err)
 		return ctrl.Result{}, err
 	}
@@ -108,7 +110,7 @@ func (r *ManagedClusterViewReconciler) Reconcile(ctx context.Context, req reconc
 	return ctrl.Result{}, nil
 }
 
-func createOrUpdateConfigMap(ctx context.Context, c client.Client, managedClusterView viewv1beta1.ManagedClusterView, logger *slog.Logger) error {
+func createOrUpdateConfigMap(ctx context.Context, c client.Client, operatorNamespace string, managedClusterView viewv1beta1.ManagedClusterView, logger *slog.Logger) error {
 	logger = logger.With("ManagedClusterView", managedClusterView.Name, "Namespace", managedClusterView.Namespace)
 
 	// Initialize an empty map to hold the result data.
@@ -176,7 +178,6 @@ func createOrUpdateConfigMap(ctx context.Context, c client.Client, managedCluste
 		}
 	}
 
-	operatorNamespace := os.Getenv("POD_NAMESPACE")
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ClientInfoConfigMapName,

--- a/controllers/managedclusterview_controller_test.go
+++ b/controllers/managedclusterview_controller_test.go
@@ -98,11 +98,11 @@ storageSystemName: "ocs-storagecluster-storagesystem"
 		err = c.Create(ctx, mcv)
 		assert.NoError(t, err)
 
-		err = createOrUpdateConfigMap(ctx, c, *mcv, logger)
+		err = createOrUpdateConfigMap(ctx, c, "openshift-operators", *mcv, logger)
 		assert.NoError(t, err)
 
 		cm := &corev1.ConfigMap{}
-		err = c.Get(ctx, types.NamespacedName{Name: ClientInfoConfigMapName, Namespace: os.Getenv("POD_NAMESPACE")}, cm)
+		err = c.Get(ctx, types.NamespacedName{Name: ClientInfoConfigMapName, Namespace: utils.GetEnv("POD_NAMESPACE")}, cm)
 		assert.NoError(t, err)
 		assert.NotNil(t, cm)
 
@@ -147,11 +147,11 @@ storageSystemName: "ocs-storagecluster-storagesystem"
 		err := c.Create(ctx, mcv)
 		assert.NoError(t, err)
 
-		err = createOrUpdateConfigMap(ctx, c, *mcv, logger)
+		err = createOrUpdateConfigMap(ctx, c, "openshift-operators", *mcv, logger)
 		assert.NoError(t, err)
 
 		cm := &corev1.ConfigMap{}
-		err = c.Get(ctx, types.NamespacedName{Name: ClientInfoConfigMapName, Namespace: os.Getenv("POD_NAMESPACE")}, cm)
+		err = c.Get(ctx, types.NamespacedName{Name: ClientInfoConfigMapName, Namespace: utils.GetEnv("POD_NAMESPACE")}, cm)
 		assert.NoError(t, err)
 		assert.NotNil(t, cm)
 

--- a/controllers/manager.go
+++ b/controllers/manager.go
@@ -92,7 +92,7 @@ func NewManagerCommand() *cobra.Command {
 		Use:   "manager",
 		Short: "Multicluster Orchestrator for ODF",
 		Run: func(cmd *cobra.Command, args []string) {
-			mgrOpts.runManager()
+			mgrOpts.runManager(cmd.Context())
 		},
 	}
 	mgrOpts.AddFlags(cmd)
@@ -134,7 +134,7 @@ func preRunGarbageCollection(cl client.Client, logger *slog.Logger) error {
 	return nil
 }
 
-func (o *ManagerOptions) runManager() {
+func (o *ManagerOptions) runManager(ctx context.Context) {
 	zapLogger := utils.GetZapLogger(o.DevMode)
 	defer func() {
 		if err := zapLogger.Sync(); err != nil {
@@ -298,7 +298,7 @@ func (o *ManagerOptions) runManager() {
 		os.Exit(1)
 	}
 
-	g, ctx := errgroup.WithContext(ctrl.SetupSignalHandler())
+	g, ctx := errgroup.WithContext(ctx)
 
 	logger.Info("Starting manager")
 	g.Go(func() error {

--- a/controllers/mirrorpeer_controller_test.go
+++ b/controllers/mirrorpeer_controller_test.go
@@ -111,7 +111,7 @@ func getFakeMirrorPeerReconciler(mirrorpeer multiclusterv1alpha1.MirrorPeer) Mir
 	var odfClientInfoConfigMap = &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "odf-client-info",
-			Namespace: os.Getenv("POD_NAMESPACE"),
+			Namespace: utils.GetEnv("POD_NAMESPACE"),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: viewv1beta1.GroupVersion.String(),

--- a/controllers/mirrorpeersecret_controller.go
+++ b/controllers/mirrorpeersecret_controller.go
@@ -42,6 +42,8 @@ type MirrorPeerSecretReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	Logger *slog.Logger
+
+	testEnvFile string
 }
 
 //+kubebuilder:rbac:groups=multicluster.odf.openshift.io,resources=mirrorpeers,verbs=get;list;watch;create;update;patch;delete
@@ -85,8 +87,9 @@ func (r *MirrorPeerSecretReconciler) mirrorPeerSecretReconcile(ctx context.Conte
 		return ctrl.Result{}, err
 	}
 
+	currentNamespace := utils.GetEnv("POD_NAMESPACE", r.testEnvFile)
 	if utils.IsSecretInternal(&peerSecret) {
-		err = createOrUpdateSecretsFromInternalSecret(ctx, rc, &peerSecret, nil, logger)
+		err = createOrUpdateSecretsFromInternalSecret(ctx, rc, currentNamespace, &peerSecret, nil, logger)
 		if err != nil {
 			logger.Error("Failed to update from internal secret", "error", err, "Secret", peerSecret.Name)
 			return ctrl.Result{}, err

--- a/controllers/mirrorpeersecret_controller.go
+++ b/controllers/mirrorpeersecret_controller.go
@@ -43,7 +43,8 @@ type MirrorPeerSecretReconciler struct {
 	Scheme *runtime.Scheme
 	Logger *slog.Logger
 
-	testEnvFile string
+	testEnvFile      string
+	currentNamespace string
 }
 
 //+kubebuilder:rbac:groups=multicluster.odf.openshift.io,resources=mirrorpeers,verbs=get;list;watch;create;update;patch;delete
@@ -87,9 +88,8 @@ func (r *MirrorPeerSecretReconciler) mirrorPeerSecretReconcile(ctx context.Conte
 		return ctrl.Result{}, err
 	}
 
-	currentNamespace := utils.GetEnv("POD_NAMESPACE", r.testEnvFile)
 	if utils.IsSecretInternal(&peerSecret) {
-		err = createOrUpdateSecretsFromInternalSecret(ctx, rc, currentNamespace, &peerSecret, nil, logger)
+		err = createOrUpdateSecretsFromInternalSecret(ctx, rc, r.currentNamespace, &peerSecret, nil, logger)
 		if err != nil {
 			logger.Error("Failed to update from internal secret", "error", err, "Secret", peerSecret.Name)
 			return ctrl.Result{}, err

--- a/controllers/utils/clients.go
+++ b/controllers/utils/clients.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetClientFromConfig returns a controller-runtime Client for a rest.Config
+func GetClientFromConfig(config *rest.Config, scheme *runtime.Scheme) (client.Client, error) {
+	cl, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+	return cl, nil
+}
+
+// GetClientConfig returns the rest.Config for a kubeconfig file
+func GetClientConfig(kubeConfigFile string) (*rest.Config, error) {
+	clientconfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("get clientconfig failed: %w", err)
+	}
+	return clientconfig, nil
+}

--- a/controllers/utils/env.go
+++ b/controllers/utils/env.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+func GetEnv(key string, filenames ...string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+
+	if len(filenames) == 0 {
+		return ""
+	}
+
+	envMap, err := godotenv.Read(filenames...)
+	if err != nil {
+		return ""
+	}
+
+	if value, ok := envMap[key]; ok {
+		return value
+	}
+
+	return ""
+}
+
+func GetEnvOrDefault(key, defaultValue string, filenames ...string) string {
+	if value := GetEnv(key, filenames...); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/controllers/utils/peer_ref.go
+++ b/controllers/utils/peer_ref.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"os"
 
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
@@ -56,7 +55,7 @@ func GetPeerRefForSpokeCluster(mp *multiclusterv1alpha1.MirrorPeer, spokeCluster
 // GetPeerRefForProviderCluster returns the client peer ref for the current provider cluster
 func GetPeerRefForProviderCluster(ctx context.Context, spokeClient, hubClient client.Client, mp *multiclusterv1alpha1.MirrorPeer) ([]multiclusterv1alpha1.PeerRef, error) {
 	var peerRefList []multiclusterv1alpha1.PeerRef
-	operatorNamespace := os.Getenv("POD_NAMESPACE")
+	operatorNamespace := GetEnv("POD_NAMESPACE")
 	cm, err := GetODFInfoConfigMap(ctx, spokeClient, operatorNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ODF Info ConfigMap for namespace %s: %w", operatorNamespace, err)
@@ -94,7 +93,7 @@ func GetClusterID(ctx context.Context, client client.Client, clusterName string)
 
 func getPeerRefType(ctx context.Context, c client.Client, peerRef multiclusterv1alpha1.PeerRef, isManagedCluster bool) (PeerRefType, error) {
 	if isManagedCluster {
-		operatorNamespace := os.Getenv("POD_NAMESPACE")
+		operatorNamespace := GetEnv("POD_NAMESPACE")
 		cm, err := GetODFInfoConfigMap(ctx, c, operatorNamespace)
 		if err != nil {
 			return PeerRefTypeUnknown, fmt.Errorf("failed to get ODF Info ConfigMap for namespace %s: %w", peerRef.StorageClusterRef.Namespace, err)
@@ -116,7 +115,7 @@ func getPeerRefType(ctx context.Context, c client.Client, peerRef multiclusterv1
 		}
 		return PeerRefTypeStorageCluster, nil
 	} else {
-		operatorNamespace := os.Getenv("POD_NAMESPACE")
+		operatorNamespace := GetEnv("POD_NAMESPACE")
 		cm, err := FetchConfigMap(ctx, c, ClientInfoConfigMapName, operatorNamespace)
 		if k8serrors.IsNotFound(err) {
 			return PeerRefTypeStorageCluster, nil

--- a/controllers/utils/s3.go
+++ b/controllers/utils/s3.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"os"
 
 	obv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
@@ -42,13 +41,6 @@ func GetCurrentStorageClusterRef(mp *multiclusterv1alpha1.MirrorPeer, spokeClust
 	}
 
 	return nil, fmt.Errorf("StorageClusterRef for cluster %s under mirrorpeer %s not found", spokeClusterName, mp.Name)
-}
-
-func GetEnv(key, defaultValue string) string {
-	if value, ok := os.LookupEnv(key); ok {
-		return value
-	}
-	return defaultValue
 }
 
 func GenerateBucketName(mirrorPeer multiclusterv1alpha1.MirrorPeer) string {

--- a/controllers/validations.go
+++ b/controllers/validations.go
@@ -68,11 +68,11 @@ func isManagedCluster(ctx context.Context, client client.Client, clusterName str
 
 // checkStorageClusterPeerStatus checks if the ManifestWorks for StorageClusterPeer resources
 // have been created and reached the Applied status.
-func checkStorageClusterPeerStatus(ctx context.Context, client client.Client, logger *slog.Logger, mirrorPeer *multiclusterv1alpha1.MirrorPeer) (bool, error) {
+func checkStorageClusterPeerStatus(ctx context.Context, client client.Client, logger *slog.Logger, currentNamespace string, mirrorPeer *multiclusterv1alpha1.MirrorPeer) (bool, error) {
 	logger.Info("Checking if StorageClusterPeer ManifestWorks have been created and reached Applied status")
 
 	// Fetch the client info ConfigMap
-	clientInfoMap, err := fetchClientInfoConfigMap(ctx, client)
+	clientInfoMap, err := fetchClientInfoConfigMap(ctx, client, currentNamespace)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.Info("Client info ConfigMap not found; requeuing for later retry")
@@ -135,11 +135,11 @@ func checkStorageClusterPeerStatus(ctx context.Context, client client.Client, lo
 
 // checkClientPairingConfigMapStatus checks if the ManifestWorks for client pairing ConfigMaps
 // have been created and reached the Applied status.
-func checkClientPairingConfigMapStatus(ctx context.Context, client client.Client, logger *slog.Logger, mirrorPeer *multiclusterv1alpha1.MirrorPeer) (bool, error) {
+func checkClientPairingConfigMapStatus(ctx context.Context, client client.Client, logger *slog.Logger, currentNamespace string, mirrorPeer *multiclusterv1alpha1.MirrorPeer) (bool, error) {
 	logger.Info("Checking if client pairing ConfigMap ManifestWorks have been created and reached Applied status")
 
 	// Fetch the client info ConfigMap
-	clientInfoMap, err := fetchClientInfoConfigMap(ctx, client)
+	clientInfoMap, err := fetchClientInfoConfigMap(ctx, client, currentNamespace)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.Info("Client info ConfigMap not found; requeuing for later retry")

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/csi-addons/kubernetes-csi-addons v0.8.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/uuid v1.6.0
+	github.com/joho/godotenv v1.5.1
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20221122204822-d1a8c34382f1
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.0.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=


### PR DESCRIPTION
The changes in this PR started off as a way to enable development and testing on local environment.  But, the changes are useful beyond that.

- [run golangci-lint before integration tests](https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/279/commits/869db06f8171dbffe2dbf5f8a6855bb864f82c37)
Before running integration tests, we want to catch linter error just like we do with unit tests.

- [explicitly name the MirrorPeer controller on spoke](https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/279/commits/b7f636461bc2273da0040ed4d045f027275eb037)
We have 2 MirrorPeer controllers - one runs on the hub and the other
runs on spoke cluster. If in case, same cluster is used as hub and spoke,
there are chances of one of these controllers failing to register itself
because it is considered a duplicate. So this commit explicitly sets a
name for the agent mirrorpeer controller to disambiguate.

- [pass kubeconfig to controllers when running out-of-cluster](https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/279/commits/fe74e6df65f5cb6ad0cb87b8b8918303fa47c60c)
 When we are running controllers locally against a remote cluster,
we need to be able to pass the kubeconfig file for that cluster.
This kubeconfig is then converted to a rest.Config and passed on
to the manager. Without the kubeconfig file, we will not be able
to run the controllers locally.

- [add a ExecuteCommandForTest function](https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/279/commits/9a9a2d8e8f3ceabd51be2b77bc6a075fbc073d0e)
For integration testing, we need to be able to customize command
configuration to control various aspects like output stream, error
stream etc. This commit adds a function that allows us to customize
the command as required and execute it on the fly.

- [set a single global context for all the commands](https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/279/commits/bbe8b89f30693e7898ee48390e5c0409cce1ffbd)
We want to use a single global context for program execution. This allows us to gracefully shutdown everything by simply cancelling the global context.

- [read configuration from envvar or dotenv file as needed](https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/279/commits/b220b9744e71e09f47e4b1efba57718203c8a224)
While running in-cluster deployments, some runtime parameters are
provided as environment variables via Kubernetes downward-API and
other schemes. But, while running out-of-cluster deployments, same
schemes may not be possible. For such cases, this commit adds a
capability to provide parameters as dotenv file. The dotenv file
path should be provided as an argument during deployment.

  Running out-of-cluster is usually only preferred for developement
environments and should not be used for production.

- [set currentNamespace on all controllers during startup](https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/279/commits/0add6380dd44a8ed74450f7bfed852f2b13af892)
The current namespace in which the controller is running does not change.
So, it is enough to get the current namespace when the controllers are
starting and re-use it. This commit adds the current namespace as a
private field of the reconciler and initializes it during startup.
All subsequent functions that requires the current execution namespace
will receive it from the reconciler.