### PR TITLE
add build version and version compatibility check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,12 @@ COPY controllers/ controllers/
 COPY cmd/ cmd/
 COPY addons/ addons/
 COPY console/ console/
+COPY version/ version/
+
+ARG LDFLAGS
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,13 @@ endif
 ##@ Build
 
 build: generate fmt vet golangci-lint kube-linter ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -ldflags=${LDFLAGS} -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 operator-build: generate fmt vet golangci-lint kube-linter ## Build docker image with the manager.
-	${BUILD_TOOL} build -t ${IMG} .
+	${BUILD_TOOL} build --build-arg=LDFLAGS=${LDFLAGS} -t ${IMG} .
 
 operator-push: ## Push docker image with the manager.
 	${BUILD_TOOL} push ${IMG}

--- a/addons/agent_mirrorpeer_controller.go
+++ b/addons/agent_mirrorpeer_controller.go
@@ -347,6 +347,9 @@ func (r *MirrorPeerReconciler) hasSpokeCluster(obj client.Object) bool {
 	if !ok {
 		return false
 	}
+	if mp.Status.Phase == multiclusterv1alpha1.IncompatibleVersion {
+		return false
+	}
 	for _, v := range mp.Spec.Items {
 		if v.ClusterName == r.SpokeClusterName {
 			return true
@@ -381,6 +384,9 @@ func (r *MirrorPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return reqs
 		}
 		for _, mirrorpeer := range mirrorPeerList.Items {
+			if mirrorpeer.Status.Phase == multiclusterv1alpha1.IncompatibleVersion {
+				continue
+			}
 			for _, peerRef := range mirrorpeer.Spec.Items {
 				name := utils.GetSecretNameByPeerRef(peerRef)
 				if name == obj.GetName() {

--- a/api/v1alpha1/mirrorpeer_types.go
+++ b/api/v1alpha1/mirrorpeer_types.go
@@ -24,13 +24,14 @@ type PhaseType string
 type DRType string
 
 const (
-	ExchangingSecret PhaseType = "ExchangingSecret"
-	ExchangedSecret  PhaseType = "ExchangedSecret"
-	S3ProfileSynced  PhaseType = "S3ProfileSynced"
-	S3ProfileSyncing PhaseType = "S3ProfileSyncing"
-	Deleting         PhaseType = "Deleting"
-	Sync             DRType    = "sync"
-	Async            DRType    = "async"
+	IncompatibleVersion PhaseType = "IncompatibleVersion"
+	ExchangingSecret    PhaseType = "ExchangingSecret"
+	ExchangedSecret     PhaseType = "ExchangedSecret"
+	S3ProfileSynced     PhaseType = "S3ProfileSynced"
+	S3ProfileSyncing    PhaseType = "S3ProfileSyncing"
+	Deleting            PhaseType = "Deleting"
+	Sync                DRType    = "sync"
+	Async               DRType    = "async"
 )
 
 // StorageClusterRef holds a reference to a StorageCluster

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/version"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
@@ -19,6 +20,7 @@ var rootCmd = &cobra.Command{
 		}
 		os.Exit(1)
 	},
+	Version: version.Version,
 }
 
 func Execute() {

--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -56,6 +56,7 @@ type MirrorPeerReconciler struct {
 
 	testEnvFile      string
 	currentNamespace string
+	clientInfoMap    map[string]string
 }
 
 const (
@@ -107,6 +108,17 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	clientInfoMap, err := fetchClientInfoConfigMap(ctx, r.Client, r.currentNamespace)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("ConfigMap 'odf-client-info' not found. Requeueing.")
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	r.clientInfoMap = clientInfoMap.Data
+	logger.Info("ConfigMap 'odf-client-info' cached successfully.")
+
 	logger.Info("Validating MirrorPeer")
 	// Validate MirrorPeer
 	// MirrorPeer.Spec must be defined
@@ -130,6 +142,18 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			logger.Error("Invalid ManagedCluster", "ClusterName", mirrorPeer.Spec.Items[i].ClusterName, "error", err)
 			return ctrl.Result{}, err
 		}
+		// MirrorPeer.Spec.Items[*].StorageClusterRef must have a compatible version
+		if err := isVersionCompatible(mirrorPeer.Spec.Items[i], r.clientInfoMap); err != nil {
+			logger.Error("Can not reconcile MirrorPeer", "error", err)
+			mirrorPeer.Status.Phase = multiclusterv1alpha1.IncompatibleVersion
+			mirrorPeer.Status.Message = err.Error()
+			statusErr := r.Client.Status().Update(ctx, &mirrorPeer)
+			if statusErr != nil {
+				logger.Error("Error occurred while updating the status of mirrorpeer. Requeing request.", "Error ", statusErr)
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{Requeue: false}, nil
+		}
 	}
 	logger.Info("All validations for MirrorPeer passed")
 
@@ -137,6 +161,19 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if !utils.ContainsString(mirrorPeer.GetFinalizers(), mirrorPeerFinalizer) {
 			logger.Info("Finalizer not found on MirrorPeer. Adding Finalizer")
 			mirrorPeer.Finalizers = append(mirrorPeer.Finalizers, mirrorPeerFinalizer)
+		}
+		if mirrorPeer.Status.Phase == "" || mirrorPeer.Status.Phase == multiclusterv1alpha1.IncompatibleVersion {
+			if mirrorPeer.Spec.Type == multiclusterv1alpha1.Async {
+				mirrorPeer.Status.Phase = multiclusterv1alpha1.ExchangingSecret
+			} else {
+				mirrorPeer.Status.Phase = multiclusterv1alpha1.S3ProfileSyncing
+			}
+			statusErr := r.Client.Status().Update(ctx, &mirrorPeer)
+			if statusErr != nil {
+				logger.Error("Error occurred while updating the status of mirrorpeer. Re-queing request.", "Error ", statusErr)
+				// Requeue, but don't throw
+				return ctrl.Result{Requeue: true}, nil
+			}
 		}
 	} else {
 		logger.Info("Deleting MirrorPeer")
@@ -181,20 +218,6 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		logger.Info("Successfully added label to mirrorpeer for disaster recovery. Requeing request...")
 		return ctrl.Result{Requeue: true}, nil
-	}
-
-	if mirrorPeer.Status.Phase == "" {
-		if mirrorPeer.Spec.Type == multiclusterv1alpha1.Async {
-			mirrorPeer.Status.Phase = multiclusterv1alpha1.ExchangingSecret
-		} else {
-			mirrorPeer.Status.Phase = multiclusterv1alpha1.S3ProfileSyncing
-		}
-		statusErr := r.Client.Status().Update(ctx, &mirrorPeer)
-		if statusErr != nil {
-			logger.Error("Error occurred while updating the status of mirrorpeer. Requeing request...", "Error ", statusErr)
-			// Requeue, but don't throw
-			return ctrl.Result{Requeue: true}, nil
-		}
 	}
 
 	// Check if the MirrorPeer contains StorageClient reference

--- a/controllers/validations.go
+++ b/controllers/validations.go
@@ -22,8 +22,10 @@ import (
 	"log/slog"
 	"reflect"
 
+	"github.com/blang/semver/v4"
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/utils"
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/version"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +64,29 @@ func isManagedCluster(ctx context.Context, client client.Client, clusterName str
 			return fmt.Errorf("validation: ManagedCluster %q not found : %q is not a managed cluster", clusterName, clusterName)
 		}
 		return fmt.Errorf("validation: unable to get ManagedCluster %q: error: %v", clusterName, err)
+	}
+	return nil
+}
+
+func isVersionCompatible(peerRef multiclusterv1alpha1.PeerRef, clientInfoMap map[string]string) error {
+	clientInfo, err := getClientInfoFromConfigMap(clientInfoMap, utils.GetKey(peerRef.ClusterName, peerRef.StorageClusterRef.Name))
+	if err != nil {
+		return fmt.Errorf("validation: unable to get client info: error: %v", err)
+	}
+	spokeVersion, err := semver.Parse(clientInfo.ProviderInfo.Version)
+	if err != nil {
+		return fmt.Errorf("validation: unable to parse spoke version: error: %v", err)
+	}
+	spokeVersion.Pre = nil
+	spokeVersion.Build = nil
+	hubVersion, err := semver.Parse(version.Version)
+	if err != nil {
+		return fmt.Errorf("validation: unable to parse hub version: error: %v", err)
+	}
+	hubVersion.Pre = nil
+	hubVersion.Build = nil
+	if !spokeVersion.Equals(hubVersion) {
+		return fmt.Errorf("storage cluster version %q on ManagedCluster %q is incompatible with Multicluster Orchestrator version %q", spokeVersion, peerRef.ClusterName, hubVersion)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.6
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/csi-addons/kubernetes-csi-addons v0.8.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/uuid v1.6.0
@@ -38,7 +39,6 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containernetworking/cni v1.2.3 // indirect

--- a/hack/make/vars.mk
+++ b/hack/make/vars.mk
@@ -6,6 +6,7 @@
 VERSION ?= 0.0.1
 RAMEN_VERSION ?= 0.0.1
 FUSION ?= false
+LDFLAGS ?= "-X github.com/red-hat-storage/odf-multicluster-orchestrator/version.Version=${VERSION}"
 
 IMAGE_REGISTRY ?= quay.io
 REGISTRY_NAMESPACE ?= ocs-dev

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	// Version of the operator
+	Version = "4.19.0"
+)


### PR DESCRIPTION
When hub and spoke are running different versions, we might have configuration mismatches. We expect both hub and spoke components to be on same versions. If they are not, we simply do not reconcile them.