### PR TITLE
add secret watcher and debug logs to DRPolicy reconciler

### DIFF
--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -57,6 +57,7 @@ func (r *DRPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	dpPredicate := utils.ComposePredicates(predicate.GenerationChangedPredicate{})
 
 	tokenToDRPolicyMapFunc := func(ctx context.Context, obj client.Object) []ctrl.Request {
+		r.Logger.Debug("Mapping secret to DRPolicy", "SecretName", obj.GetName(), "SecretNamespace", obj.GetNamespace())
 		reqs := []ctrl.Request{}
 		var mirrorPeerList multiclusterv1alpha1.MirrorPeerList
 		err := r.HubClient.List(ctx, &mirrorPeerList)
@@ -64,33 +65,40 @@ func (r *DRPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			r.Logger.Error("Unable to reconcile DRPolicy based on token changes. Failed to list MirrorPeers.", "error", err)
 			return reqs
 		}
+		r.Logger.Debug("Fetched MirrorPeers", "count", len(mirrorPeerList.Items))
 		for _, mirrorpeer := range mirrorPeerList.Items {
 			for _, peerRef := range mirrorpeer.Spec.Items {
 				name := utils.GetSecretNameByPeerRef(peerRef)
+				r.Logger.Debug("GetSecretNameByPeerRef()", "MirrorPeer", mirrorpeer.GetName(), "peerRef", peerRef, "SecretName", name)
 				if name == obj.GetName() {
+					r.Logger.Debug("GetSecretNameByPeerRef() == obj.GetName()", "MirrorPeer", mirrorpeer.GetName(), "peerRef", peerRef, "SecretName", name, "ObjectName", obj.GetName())
 					var drpolicyList ramenv1alpha1.DRPolicyList
 					err := r.HubClient.List(ctx, &drpolicyList)
 					if err != nil {
 						r.Logger.Error("Unable to reconcile DRPolicy based on token changes. Failed to list DRPolicies", "error", err)
 						return reqs
 					}
+					r.Logger.Debug("Fetched DRPolicies", "count", len(drpolicyList.Items))
 					for _, drpolicy := range drpolicyList.Items {
 						for i := range drpolicy.Spec.DRClusters {
 							if drpolicy.Spec.DRClusters[i] == peerRef.ClusterName {
+								r.Logger.Debug("drpolicy.Spec.DRClusters == peerRef.ClusterName", "DRPolicy", drpolicy.GetName(), "DRCluster", drpolicy.Spec.DRClusters[i], "peerRef.ClusterName", peerRef.ClusterName)
 								reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: drpolicy.Name}})
 							}
 						}
 					}
 					break
 				}
+				r.Logger.Debug("GetSecretNameByPeerRef() != obj.GetName()", "MirrorPeer", mirrorpeer.GetName(), "peerRef", peerRef, "SecretName", name, "ObjectName", obj.GetName())
 			}
 		}
+		r.Logger.Info("DRPolicy reconcile requests generated based on token change.", "RequestCount", len(reqs), "Requests", reqs, "TokenName", obj.GetName())
 		return reqs
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ramenv1alpha1.DRPolicy{}, builder.WithPredicates(dpPredicate)).
-		WatchesMetadata(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(tokenToDRPolicyMapFunc), builder.WithPredicates(utils.SourceOrDestinationPredicate)).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(tokenToDRPolicyMapFunc), builder.WithPredicates(utils.SourcePredicate)).
 		Complete(r)
 }
 

--- a/controllers/utils/predicate.go
+++ b/controllers/utils/predicate.go
@@ -23,6 +23,21 @@ var SourceOrDestinationPredicate = predicate.Funcs{
 	},
 }
 
+var SourcePredicate = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return IsSecretSource(e.Object)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return IsSecretSource(e.Object)
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return (IsSecretSource(e.ObjectOld) && IsSecretSource(e.ObjectNew))
+	},
+	GenericFunc: func(_ event.GenericEvent) bool {
+		return false
+	},
+}
+
 // ComposePredicates will compose a variable number of predicates and return a predicate that
 // will allow events that are allowed by any of the given predicates.
 func ComposePredicates(predicates ...predicate.Predicate) predicate.Predicate {


### PR DESCRIPTION
WatchObjectMeta does not watch for changes in content of secrets. We need to use Watch on Secrets. To filter the list of secrets, we add a predicate to only watch for source secrets.

Also, added  some debug logs to help us track reconcile requests during debugging.