### PR TITLE
add external mode odf config to odf-client-info ConfigMap

### DIFF
--- a/controllers/utils/clientinfo.go
+++ b/controllers/utils/clientinfo.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type ProviderInfo struct {
+	Version                       string               `json:"version"`
+	DeploymentType                string               `json:"deploymentType"`
+	StorageSystemName             string               `json:"storageSystemName"`
+	ProviderManagedClusterName    string               `json:"providerManagedClusterName"`
+	NamespacedName                types.NamespacedName `json:"namespacedName"`
+	StorageProviderEndpoint       string               `json:"storageProviderEndpoint"`
+	CephClusterFSID               string               `json:"cephClusterFSID"`
+	StorageProviderPublicEndpoint string               `json:"storageProviderPublicEndpoint"`
+}
+
+type ClientInfo struct {
+	ClusterID                string       `json:"clusterId"`
+	Name                     string       `json:"name"`
+	ProviderInfo             ProviderInfo `json:"providerInfo,omitempty"`
+	ClientManagedClusterName string       `json:"clientManagedClusterName,omitempty"`
+	ClientID                 string       `json:"clientId"`
+}
+
+// Helper function to extract and unmarshal ClientInfo from ConfigMap
+func GetClientInfoFromConfigMap(clientInfoMap map[string]string, key string) (ClientInfo, error) {
+	clientInfoJSON, ok := clientInfoMap[key]
+	if !ok {
+		return ClientInfo{}, fmt.Errorf("client info for %s not found in ConfigMap", key)
+	}
+
+	var clientInfo ClientInfo
+	if err := json.Unmarshal([]byte(clientInfoJSON), &clientInfo); err != nil {
+		return ClientInfo{}, fmt.Errorf("failed to unmarshal client info for %s: %v", key, err)
+	}
+
+	return clientInfo, nil
+}

--- a/controllers/utils/configmap.go
+++ b/controllers/utils/configmap.go
@@ -41,6 +41,10 @@ func GetODFInfoConfigMap(ctx context.Context, c client.Client, namespace string)
 	return FetchConfigMap(ctx, c, ODFInfoConfigMapName, namespace)
 }
 
+func FetchClientInfoConfigMap(ctx context.Context, c client.Client, currentNamespace string) (*corev1.ConfigMap, error) {
+	return FetchConfigMap(ctx, c, ClientInfoConfigMapName, currentNamespace)
+}
+
 func SplitKeyForNamespacedName(key string) types.NamespacedName {
 	// key = openshift-storage_ocs-storagecluster.config.yaml
 	splitKey := strings.Split(key, ".")               // [openshift-storage_ocs-storagecluster,config,yaml]

--- a/controllers/validations.go
+++ b/controllers/validations.go
@@ -68,7 +68,7 @@ func isManagedCluster(ctx context.Context, client client.Client, clusterName str
 }
 
 func isVersionCompatible(peerRef multiclusterv1alpha1.PeerRef, clientInfoMap map[string]string) error {
-	clientInfo, err := getClientInfoFromConfigMap(clientInfoMap, utils.GetKey(peerRef.ClusterName, peerRef.StorageClusterRef.Name))
+	clientInfo, err := utils.GetClientInfoFromConfigMap(clientInfoMap, utils.GetKey(peerRef.ClusterName, peerRef.StorageClusterRef.Name))
 	if err != nil {
 		return fmt.Errorf("validation: unable to get client info: error: %v", err)
 	}
@@ -88,7 +88,7 @@ func checkStorageClusterPeerStatus(ctx context.Context, client client.Client, lo
 	logger.Info("Checking if StorageClusterPeer ManifestWorks have been created and reached Applied status")
 
 	// Fetch the client info ConfigMap
-	clientInfoMap, err := fetchClientInfoConfigMap(ctx, client, currentNamespace)
+	clientInfoMap, err := utils.FetchClientInfoConfigMap(ctx, client, currentNamespace)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.Info("Client info ConfigMap not found; requeuing for later retry")
@@ -99,10 +99,10 @@ func checkStorageClusterPeerStatus(ctx context.Context, client client.Client, lo
 
 	// Collect client information for each cluster in the MirrorPeer
 	items := mirrorPeer.Spec.Items
-	clientInfos := make([]ClientInfo, 0, len(items))
+	clientInfos := make([]utils.ClientInfo, 0, len(items))
 	for _, item := range items {
 		clientKey := utils.GetKey(item.ClusterName, item.StorageClusterRef.Name)
-		ci, err := getClientInfoFromConfigMap(clientInfoMap.Data, clientKey)
+		ci, err := utils.GetClientInfoFromConfigMap(clientInfoMap.Data, clientKey)
 		if err != nil {
 			logger.Error("Failed to get client info from ConfigMap", "ClientKey", clientKey)
 			return false, err
@@ -155,7 +155,7 @@ func checkClientPairingConfigMapStatus(ctx context.Context, client client.Client
 	logger.Info("Checking if client pairing ConfigMap ManifestWorks have been created and reached Applied status")
 
 	// Fetch the client info ConfigMap
-	clientInfoMap, err := fetchClientInfoConfigMap(ctx, client, currentNamespace)
+	clientInfoMap, err := utils.FetchClientInfoConfigMap(ctx, client, currentNamespace)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.Info("Client info ConfigMap not found; requeuing for later retry")
@@ -166,10 +166,10 @@ func checkClientPairingConfigMapStatus(ctx context.Context, client client.Client
 
 	// Collect client information for each cluster in the MirrorPeer
 	items := mirrorPeer.Spec.Items
-	clientInfos := make([]ClientInfo, 0, len(items))
+	clientInfos := make([]utils.ClientInfo, 0, len(items))
 	for _, item := range items {
 		clientKey := utils.GetKey(item.ClusterName, item.StorageClusterRef.Name)
-		ci, err := getClientInfoFromConfigMap(clientInfoMap.Data, clientKey)
+		ci, err := utils.GetClientInfoFromConfigMap(clientInfoMap.Data, clientKey)
 		if err != nil {
 			logger.Error("Failed to get client info from ConfigMap", "ClientKey", clientKey)
 			return false, err


### PR DESCRIPTION
The odf-client-info is created for all ODF deployment types. But, its data is only populated when ODF accepts client connections. This commit changes that behavior to populate data even in case of external mode deployments which does not accept client connections. A hypothetical client is assumed and used to create a map key as one does not exist for external mode.