### PR TITLE
fix DRCluster creation

### DIFF
--- a/tests/integration/mirrorpeer_controller_test.go
+++ b/tests/integration/mirrorpeer_controller_test.go
@@ -56,11 +56,17 @@ var (
 	mirrorPeerLookupKey = types.NamespacedName{Namespace: mirrorPeer.Namespace, Name: mirrorPeer.Name}
 )
 
-func GetFakeS3SecretForPeerRef(peer multiclusterv1alpha1.PeerRef) *v1.Secret {
+func GetFakeS3SecretForPeerRef(peer multiclusterv1alpha1.PeerRef, mirrorPeer *multiclusterv1alpha1.MirrorPeer) *v1.Secret {
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.GetSecretNameByPeerRef(peer, utils.S3ProfilePrefix),
 			Namespace: peer.ClusterName,
+			Labels: map[string]string{
+				"multicluster.odf.openshift.io/secret-type": "INTERNAL",
+			},
+			Annotations: map[string]string{
+				"multicluster.odf.openshift.io/mirrorpeer": mirrorPeer.Name,
+			},
 		},
 		Data: map[string][]byte{
 			"namespace":            []byte("openshift-storage"),

--- a/tests/integration/ramen_test.go
+++ b/tests/integration/ramen_test.go
@@ -79,14 +79,24 @@ var _ = Describe("Ramen Resource Tests", func() {
 					},
 				},
 			},
+			ManageS3: true,
+		},
+	}
+	fakeRamenConfig := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ramen-hub-operator-config",
+			Namespace: "openshift-operators",
+		},
+		Data: map[string]string{
+			"ramen_manager_config.yaml": "{\"ramenControllerType\": \"hub\",}",
 		},
 	}
 
 	pr1 := fakeMirrorPeer.Spec.Items[0]
 	pr2 := fakeMirrorPeer.Spec.Items[1]
 
-	s3sec1 := GetFakeS3SecretForPeerRef(pr1)
-	s3sec2 := GetFakeS3SecretForPeerRef(pr2)
+	s3sec1 := GetFakeS3SecretForPeerRef(pr1, fakeMirrorPeer)
+	s3sec2 := GetFakeS3SecretForPeerRef(pr2, fakeMirrorPeer)
 
 	When("MirrorPeer is reconciled", func() {
 
@@ -104,6 +114,8 @@ var _ = Describe("Ramen Resource Tests", func() {
 			err = k8sClient.Create(context.TODO(), s3sec1, &client.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			err = k8sClient.Create(context.TODO(), s3sec2, &client.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = k8sClient.Create(context.TODO(), &fakeRamenConfig, &client.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			err = k8sClient.Create(context.TODO(), fakeMirrorPeer, &client.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -124,6 +136,8 @@ var _ = Describe("Ramen Resource Tests", func() {
 			err = k8sClient.Delete(context.TODO(), s3sec1, &client.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			err = k8sClient.Delete(context.TODO(), s3sec2, &client.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			err = k8sClient.Delete(context.TODO(), &fakeRamenConfig, &client.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			err = k8sClient.Delete(context.TODO(), fakeMirrorPeer, &client.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
DRCluster resource requires S3ProfileName. We can only get it if we are the ones managing S3 configuration. So, we check if we are managing S3, get the S3 profile name and create DRCluster.