### PR TITLE
DFBUGS-2276: ensure OBC spec is not reset unexpectedly

### DIFF
--- a/controllers/utils/s3.go
+++ b/controllers/utils/s3.go
@@ -58,10 +58,8 @@ func CreateOrUpdateObjectBucketClaim(ctx context.Context, c client.Client, bucke
 	}
 
 	operationResult, err := controllerutil.CreateOrUpdate(ctx, c, noobaaOBC, func() error {
-		noobaaOBC.Spec = obv1alpha1.ObjectBucketClaimSpec{
-			BucketName:       bucketName,
-			StorageClassName: fmt.Sprintf("%s.noobaa.io", bucketNamespace),
-		}
+		noobaaOBC.Spec.BucketName = bucketName
+		noobaaOBC.Spec.StorageClassName = fmt.Sprintf("%s.noobaa.io", bucketNamespace)
 
 		if noobaaOBC.Annotations == nil {
 			noobaaOBC.Annotations = annotations


### PR DESCRIPTION
When creating or updating an OBC, we only manage certain fields. There are other fields managed by other agents. We should not reset those fields whhen we update the resource.