### PR TITLE
[release-4.18] Fix storageid generation

### DIFF
--- a/controllers/utils/hash_test.go
+++ b/controllers/utils/hash_test.go
@@ -110,3 +110,64 @@ func TestCreateUniqueReplicationId(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateMD5Hash(t *testing.T) {
+	type args struct {
+		value any
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "RBD with empty CephFSID",
+			args: args{
+				value: [2]string{"", ""},
+			},
+			want: "2432510f5993984b053e7d74ce53d94c",
+		},
+		{
+			name: "CephFS with empty CephFSID",
+			args: args{
+				value: [2]string{"", "csi"},
+			},
+			want: "793b48b9b17bdad5cd141e6daadfdd4e",
+		},
+		{
+			name: "C1/RBD",
+			args: args{
+				value: [2]string{"a0eaa723-bf87-48db-ad11-17e276edda61", ""},
+			},
+			want: "bb2361459436fd47121419c658d4c79b",
+		},
+		{
+			name: "C1/CephFS",
+			args: args{
+				value: [2]string{"a0eaa723-bf87-48db-ad11-17e276edda61", "csi"},
+			},
+			want: "41711cb35464e85f4446ace583adbaa1",
+		},
+		{
+			name: "C2/RBD",
+			args: args{
+				value: [2]string{"30dc85db-f35f-4c03-bb43-c8592487d8b9", ""},
+			},
+			want: "9e4fbb3d9e52875d6393409a51927243",
+		},
+		{
+			name: "C2/CephFS",
+			args: args{
+				value: [2]string{"30dc85db-f35f-4c03-bb43-c8592487d8b9", "csi"},
+			},
+			want: "4b7e331b508946ca7165f14804c37ffc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CalculateMD5Hash(tt.args.value); got != tt.want {
+				t.Errorf("CalculateMD5Hash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/utils/storageclass.go
+++ b/controllers/utils/storageclass.go
@@ -121,8 +121,11 @@ func CalculateStorageId(ctx context.Context, c client.Client, sc *storagev1.Stor
 	}
 
 	cephClusterFSID := cephCluster.Status.CephStatus.FSID
-	var storageId string
+	if cephClusterFSID == "" {
+		return "", fmt.Errorf("failed to calculate StorageID. Ceph FSID is empty")
+	}
 
+	var storageId string
 	switch sc.Provisioner {
 	case fmt.Sprintf(RBDProvisionerTemplate, storageClusterNamespacedName.Namespace):
 		storageId = CalculateMD5Hash([2]string{cephClusterFSID, DefaultRadosNamespace})


### PR DESCRIPTION
There can be cases where Ceph FSID is not yet initialized or missing from the server response. In such cases, it is better to error out early than to proceed with incorrect state.

We also reconcile all blue secrets irrespective of the changes to ensure that we do not miss out on any updates. Additionally, we watch CephCluster for FSID changes.