### PR TITLE
add StorageClusterPeer status feedback to ManifestWork

### DIFF
--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -444,7 +445,7 @@ func updateProviderConfigMap(logger *slog.Logger, ctx context.Context, client cl
 	}
 
 	logger.Info("Creating or updating ManifestWork with updated ConfigMap")
-	_, err = utils.CreateOrUpdateManifestWork(ctx, client, manifestWorkName, manifestWorkNamespace, updatedObjJson, ownerRef)
+	_, err = utils.CreateOrUpdateManifestWork(ctx, client, manifestWorkName, manifestWorkNamespace, updatedObjJson, []workv1.ManifestConfigOption{}, ownerRef)
 	if err != nil {
 		return fmt.Errorf("failed to update ManifestWork for provider %s: %w", providerName, err)
 	}
@@ -537,7 +538,28 @@ func createStorageClusterPeer(ctx context.Context, client client.Client, logger 
 		// The namespace of Provider A is where this ManifestWork will be created on the hub
 		namespace := currentClient.ProviderInfo.ProviderManagedClusterName
 
-		operationResult, err := utils.CreateOrUpdateManifestWork(ctx, client, manifestWorkName, namespace, storageClusterPeerJson, ownerRef)
+		manifesConfigOption := []workv1.ManifestConfigOption{
+			{
+				ResourceIdentifier: workv1.ResourceIdentifier{
+					Group:     ocsv1.GroupVersion.Group,
+					Resource:  "storageclusterpeers",
+					Name:      storageClusterPeer.Name,
+					Namespace: storageClusterPeer.Namespace,
+				},
+				FeedbackRules: []workv1.FeedbackRule{
+					{
+						Type: workv1.JSONPathsType,
+						JsonPaths: []workv1.JsonPath{
+							{
+								Name: "state",
+								Path: ".status.state",
+							},
+						},
+					},
+				},
+			},
+		}
+		operationResult, err := utils.CreateOrUpdateManifestWork(ctx, client, manifestWorkName, namespace, storageClusterPeerJson, manifesConfigOption, ownerRef)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/controllers/utils/manifestwork.go
+++ b/controllers/utils/manifestwork.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func CreateOrUpdateManifestWork(ctx context.Context, c client.Client, name string, namespace string, objJson []byte, ownerRef metav1.OwnerReference) (controllerutil.OperationResult, error) {
+func CreateOrUpdateManifestWork(ctx context.Context, c client.Client, name string, namespace string, objJson []byte, manifestConfigOptions []workv1.ManifestConfigOption, ownerRef metav1.OwnerReference) (controllerutil.OperationResult, error) {
 	mw := workv1.ManifestWork{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -34,6 +34,9 @@ func CreateOrUpdateManifestWork(ctx context.Context, c client.Client, name strin
 					},
 				},
 			},
+		}
+		if len(manifestConfigOptions) > 0 {
+			mw.Spec.ManifestConfigs = manifestConfigOptions
 		}
 		return nil
 	})


### PR DESCRIPTION
This is to ensure we wait for StorageClusterPeer to reach Peered state before finishing the reconcile.