### PR TITLE
use odf-client-info cm to check peerRefType

### DIFF
--- a/addons/agent_mirrorpeer_controller.go
+++ b/addons/agent_mirrorpeer_controller.go
@@ -47,8 +47,9 @@ type MirrorPeerReconciler struct {
 	OdfOperatorNamespace string
 	Logger               *slog.Logger
 
-	testEnvFile      string
-	CurrentNamespace string
+	testEnvFile          string
+	CurrentNamespace     string
+	HubOperatorNamespace string
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -71,7 +72,7 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	hasStorageClientRef, err := utils.IsStorageClientType(ctx, r.SpokeClient, mirrorPeer, true)
+	hasStorageClientRef, err := utils.IsStorageClientType(ctx, r.HubClient, mirrorPeer, r.HubOperatorNamespace)
 	logger.Info("MirrorPeer has client reference?", "True/False", hasStorageClientRef)
 
 	if err != nil {

--- a/addons/setup/addon_setup.go
+++ b/addons/setup/addon_setup.go
@@ -86,6 +86,7 @@ func (a *Addons) Manifests(cluster *clusterv1.ManagedCluster, addon *addonapiv1a
 		ClusterName           string
 		AddonInstallNamespace string
 		OdfOperatorNamespace  string
+		HubOperatorNamespace  string
 		Image                 string
 		DRMode                string
 		Group                 string
@@ -94,6 +95,7 @@ func (a *Addons) Manifests(cluster *clusterv1.ManagedCluster, addon *addonapiv1a
 		KubeConfigSecret:      fmt.Sprintf("%s-hub-kubeconfig", a.AddonName),
 		AddonInstallNamespace: installNamespace,
 		OdfOperatorNamespace:  odfOperatorNamespace,
+		HubOperatorNamespace:  addon.Annotations[utils.HubOperatorNamespaceKey],
 		ClusterName:           cluster.Name,
 		Image:                 a.AgentImage,
 		DRMode:                addon.Annotations[utils.DRModeAnnotationKey],
@@ -204,6 +206,11 @@ func (a *Addons) permissionConfig(cluster *clusterv1.ManagedCluster, addon *addo
 			{
 				APIGroups: []string{"cluster.open-cluster-management.io"},
 				Resources: []string{"managedclusters"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
 		}

--- a/addons/setup/tokenexchange-manifests/spoke_deployment.yaml
+++ b/addons/setup/tokenexchange-manifests/spoke_deployment.yaml
@@ -54,3 +54,5 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HUB_OPERATOR_NAMESPACE
+          value: {{ .HubOperatorNamespace }}

--- a/controllers/mirrorpeer_controller.go
+++ b/controllers/mirrorpeer_controller.go
@@ -264,7 +264,7 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Check if the MirrorPeer contains StorageClient reference
-	hasStorageClientRef, err := utils.IsStorageClientType(ctx, r.Client, mirrorPeer, false)
+	hasStorageClientRef, err := utils.IsStorageClientType(ctx, r.Client, mirrorPeer, r.CurrentNamespace)
 	if err != nil {
 		logger.Error("Failed to determine if MirrorPeer contains StorageClient reference", "error", err)
 		return r.updateMirrorPeerStatusMessage(ctx, mirrorPeer, false, err)
@@ -608,7 +608,7 @@ func getConfig(ctx context.Context, c client.Client, currentNamespace string, mp
 	managedClusterAddonsConfig := make([]ManagedClusterAddonConfig, 0)
 
 	// Check if the MirrorPeer contains StorageClient reference
-	hasStorageClientRef, err := utils.IsStorageClientType(ctx, c, mp, false)
+	hasStorageClientRef, err := utils.IsStorageClientType(ctx, c, mp, currentNamespace)
 	if err != nil {
 		return []ManagedClusterAddonConfig{}, err
 	}
@@ -725,6 +725,7 @@ func (r *MirrorPeerReconciler) processManagedClusterAddon(ctx context.Context, m
 			annotations := make(map[string]string)
 			annotations[utils.DRModeAnnotationKey] = string(mirrorPeer.Spec.Type)
 			annotations[AddonVersionAnnotationKey] = version.Version
+			annotations[utils.HubOperatorNamespaceKey] = r.CurrentNamespace
 
 			managedClusterAddOn.Annotations = annotations
 			managedClusterAddOn.Spec.InstallNamespace = config.InstallNamespace

--- a/controllers/utils/s3.go
+++ b/controllers/utils/s3.go
@@ -31,6 +31,7 @@ const (
 	S3SecretHandlerName         = "s3"
 	DRModeAnnotationKey         = "multicluster.openshift.io/mode"
 	MirrorPeerNameAnnotationKey = "multicluster.odf.openshift.io/mirrorpeer"
+	HubOperatorNamespaceKey     = "hub.multicluster.odf.openshift.io/operator-namespace"
 )
 
 func GetCurrentStorageClusterRef(mp *multiclusterv1alpha1.MirrorPeer, spokeClusterName string) (*multiclusterv1alpha1.StorageClusterRef, error) {


### PR DESCRIPTION
Currently, getPeerRefType function checks for clienttype differently for a managedcluster vs hub cluster. In case, of managed cluster it checks the odf-info cm present in the managecluster and in such a case if we have clients with different storageclusterref then it will return wrong clientType.
Instead, use "odf-client-info" cm present on hub to check for storageclienttype of the managedclusters part of a mirrorpeer such that if we have storageclients with different storageclusterref we are able to verify the type correctly.