### PR TITLE
Handle mirrorpeer deletion for client clusters

### DIFF
--- a/addons/manager.go
+++ b/addons/manager.go
@@ -33,6 +33,7 @@ import (
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,6 +62,7 @@ func init() {
 	utilruntime.Must(extv1.AddToScheme(mgrScheme))
 	utilruntime.Must(snapshotv1.AddToScheme(mgrScheme))
 	utilruntime.Must(templatev1.AddToScheme(mgrScheme))
+	utilruntime.Must(workv1.AddToScheme(mgrScheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/addons/setup/addon_setup.go
+++ b/addons/setup/addon_setup.go
@@ -283,6 +283,11 @@ func (a *Addons) permissionConfig(cluster *clusterv1.ManagedCluster, addon *addo
 				Resources: []string{"managedclusteraddons/status"},
 				Verbs:     []string{"patch", "update"},
 			},
+			{
+				APIGroups: []string{"work.open-cluster-management.io"},
+				Resources: []string{"manifestworks"},
+				Verbs:     []string{"get", "list"},
+			},
 		}
 		return nil
 	})

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -261,6 +261,10 @@ func (r *DRPolicyReconciler) createOrUpdateManifestWorkForVRCAndVGRC(ctx context
 						APIVersion: dp.APIVersion,
 					},
 				},
+				Labels: map[string]string{
+					utils.CreatedByLabelKey:  utils.CreatorMulticlusterOrchestrator,
+					utils.CreatedForClientID: cInfo.ClientID,
+				},
 			},
 		}
 
@@ -290,6 +294,10 @@ func (r *DRPolicyReconciler) createOrUpdateManifestWorkForVRCAndVGRC(ctx context
 						UID:        dp.UID,
 						APIVersion: dp.APIVersion,
 					},
+				},
+				Labels: map[string]string{
+					utils.CreatedByLabelKey:  utils.CreatorMulticlusterOrchestrator,
+					utils.CreatedForClientID: cInfo.ClientID,
 				},
 			},
 		}
@@ -348,7 +356,7 @@ func getTemplateForVRC(vrc replicationv1alpha1.VolumeReplicationClass, templateN
 	return vrcTemplateJson, nil
 }
 
-func getTemplateForVGRC(vgrc replicationv1alpha1.VolumeGroupReplicationClass, vgrcName string, templateNamespace string) ([]byte, error) {
+func getTemplateForVGRC(vgrc replicationv1alpha1.VolumeGroupReplicationClass, vgrcName, templateNamespace string) ([]byte, error) {
 	vgrc.Name = vgrcName
 	vgrcJson, err := json.Marshal(vgrc)
 	if err != nil {

--- a/controllers/utils/secret.go
+++ b/controllers/utils/secret.go
@@ -23,6 +23,7 @@ const (
 	SecretLabelTypeKey                              = "multicluster.odf.openshift.io/secret-type"
 	CreatedByLabelKey                               = "multicluster.odf.openshift.io/created-by"
 	ObjectKindLabelKey                              = "multicluster.odf.openshift.io/object-kind"
+	CreatedForClientID                              = "multicluster.odf.openshift.io/client-id"
 	CreatorMulticlusterOrchestrator                 = "odf-multicluster-orchestrator"
 	NamespaceKey                                    = "namespace"
 	StorageClusterNameKey                           = "storage-cluster-name"


### PR DESCRIPTION
In a provider-client setup, when we have a mirrorpeer for both provider and the clients, then if we just want to delete mirrorpeer for clients it should be allowed. We should be filtering resources created only for that client and proceed for deletion accordingly.

And, if there are multiple templates for a client i.e, multiple drpolicies then until all the drpolicies are deleted we shouldn't allow the deletion of the mirrorpeer for that relationship.