### PR TITLE
DFBUGS-4218: [release-4.19] handle mirrorpeer deletion for client clusters

### DIFF
--- a/addons/agent_mirrorpeer_controller.go
+++ b/addons/agent_mirrorpeer_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"slices"
 	"time"
 
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
@@ -118,12 +117,34 @@ func (r *MirrorPeerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	} else {
 		var addonDeletionlock corev1.ConfigMap
-		err = r.SpokeClient.Get(ctx, types.NamespacedName{Namespace: r.CurrentNamespace, Name: AddonDeletionlockName}, &addonDeletionlock)
+		if err = r.SpokeClient.Get(ctx, types.NamespacedName{Namespace: r.CurrentNamespace, Name: AddonDeletionlockName}, &addonDeletionlock); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Remove finalizer if present from previous versions.
+		if err = removeFinalizerFromObject(ctx, r.SpokeClient, &addonDeletionlock, ResourceDistributionFinalizer); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		cm, err := utils.FetchClientInfoConfigMap(ctx, r.HubClient, r.HubOperatorNamespace)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
-		if slices.Contains(addonDeletionlock.GetFinalizers(), ResourceDistributionFinalizer) {
+		addonKey := ""
+		for _, peer := range mirrorPeer.Spec.Items {
+			cInfo, err := utils.GetClientInfoFromConfigMap(cm.Data, utils.GetKey(peer.ClusterName, peer.StorageClusterRef.Name))
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if cInfo.ProviderInfo.ProviderManagedClusterName == r.SpokeClusterName {
+				addonKey = cInfo.ClientID
+				break
+			}
+		}
+
+		if _, ok := addonDeletionlock.Data[addonKey]; ok {
+			logger.Info("Dependent resources like templates for mirrorpeer are not yet deleted, requing")
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 

--- a/addons/manager.go
+++ b/addons/manager.go
@@ -33,6 +33,7 @@ import (
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -60,6 +61,7 @@ func init() {
 	utilruntime.Must(extv1.AddToScheme(mgrScheme))
 	utilruntime.Must(snapshotv1.AddToScheme(mgrScheme))
 	utilruntime.Must(templatev1.AddToScheme(mgrScheme))
+	utilruntime.Must(workv1.AddToScheme(mgrScheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/addons/setup/addon_setup.go
+++ b/addons/setup/addon_setup.go
@@ -276,6 +276,11 @@ func (a *Addons) permissionConfig(cluster *clusterv1.ManagedCluster, addon *addo
 				Resources: []string{"managedclusteraddons/status"},
 				Verbs:     []string{"patch", "update"},
 			},
+			{
+				APIGroups: []string{"work.open-cluster-management.io"},
+				Resources: []string{"manifestworks"},
+				Verbs:     []string{"get", "list"},
+			},
 		}
 		return nil
 	})

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -200,6 +200,10 @@ func (r *DRPolicyReconciler) createOrUpdateManifestWorkForVRC(ctx context.Contex
 						APIVersion: dp.APIVersion,
 					},
 				},
+				Labels: map[string]string{
+					utils.CreatedByLabelKey:  utils.CreatorMulticlusterOrchestrator,
+					utils.CreatedForClientID: cInfo.ClientID,
+				},
 			},
 		}
 

--- a/controllers/utils/secret.go
+++ b/controllers/utils/secret.go
@@ -22,6 +22,7 @@ const (
 	ProviderLabel                   SecretLabelType = "PROVIDER"
 	SecretLabelTypeKey                              = "multicluster.odf.openshift.io/secret-type"
 	CreatedByLabelKey                               = "multicluster.odf.openshift.io/created-by"
+	CreatedForClientID                              = "multicluster.odf.openshift.io/client-id"
 	CreatorMulticlusterOrchestrator                 = "odf-multicluster-orchestrator"
 	NamespaceKey                                    = "namespace"
 	StorageClusterNameKey                           = "storage-cluster-name"


### PR DESCRIPTION
In a provider-client setup, when we have a mirrorpeer for both provider and the clients, then if we just want to delete mirrorpeer for clients it should be allowed. We should be filtering resources created only for that client and proceed for deletion accordingly.

And, if there are multiple manifestworks for a client i.e, multiple drpolicies then until all the drpolicies are deleted we shouldn't allow the deletion of the mirrorpeer for that relationship.


(cherry picked from commit b546a22517b45757a324f901b60678c67c623ca6)