### PR TITLE
DFBUGS-5493: [release-4.18] cve-fix: resolve CVE-2025-61726 in net/url

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.63.4
+        version: v1.64.8
 
   kube-linter:
     name: Kube YAML

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout source
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout source
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout source

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/red-hat-storage/odf-multicluster-orchestrator
 
-go 1.23.7
+go 1.24.0
 
-toolchain go1.23.10
+toolchain go1.24.13
 
 require (
 	github.com/csi-addons/kubernetes-csi-addons v0.8.0

--- a/hack/make/tools.mk
+++ b/hack/make/tools.mk
@@ -68,7 +68,7 @@ endif
 endif
 
 GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-GOLANGCI_VERSION := 1.63.4
+GOLANGCI_VERSION := 1.64.8
 
 .PHONY: golangci-bin
 GOLANGCI_BIN := $(CWD)/bin/golangci-lint


### PR DESCRIPTION
- Upgraded Go version from 1.23.10 to 1.24.13
- CVE-2025-61726: Memory exhaustion in query parameter parsing in net/url
- Vulnerability in net/url package when parsing URL-encoded forms with large numbers of query parameters can cause excessive memory consumption
- Severity: Important (Red Hat security rating)
- Updated go.mod: go 1.24.0, toolchain go1.24.13
- Updated Dockerfile: golang:1.24
- Updated GitHub workflows to use Go 1.24:
  - .github/workflows/lint.yaml
  - .github/workflows/publish-images.yaml
  - .github/workflows/test-and-build.yaml
- While vulnerable code is not currently used in codebase, upgrading ensures protection against future code changes and provides access to other security fixes

References:
- CVE: https://nvd.nist.gov/vuln/detail/cve-2025-61726
- Go Issue: https://github.com/golang/go/issues/77101
- Go Advisory: https://pkg.go.dev/vuln/GO-2026-4341
- Security Announcement: https://www.openwall.com/lists/oss-security/2026/01/15/3

Also handles:
- https://redhat.atlassian.net/browse/DFBUGS-4508
- https://redhat.atlassian.net/browse/DFBUGS-5162
