### PR TITLE
fix: Use DRPC annotation fallback for primaryCluster in PAV

### DIFF
--- a/controllers/ramen/protectedapplicationsview_controller.go
+++ b/controllers/ramen/protectedapplicationsview_controller.go
@@ -31,20 +31,21 @@ import (
 )
 
 const (
-	labelAppType                     = "app.kubernetes.io/type"
-	labelDRPolicy                    = "ramendr.openshift.io/dr-policy"
-	placementLabel                   = "cluster.open-cluster-management.io/placement"
-	applicationSetKind               = "ApplicationSet"
-	subscriptionKind                 = "Subscription"
-	drpcKind                         = "DRPlacementControl"
-	placementKind                    = "Placement"
-	requeueAfterSeconds              = time.Duration(30 * time.Second)
-	subscriptionAnnotation           = "apps.open-cluster-management.io/subscriptions"
-	ramenAPIVersion                  = "ramendr.openshift.io/v1alpha1"
-	drPolicyKind                     = "DRPolicy"
-	subscriptionAPIVersion           = "apps.open-cluster-management.io/v1"
-	clusterDecisionResourceIndexName = "spec.generators.clusterDecisionResource.placement"
-	placementIndexName               = "spec.placementRef.name"
+	labelAppType                       = "app.kubernetes.io/type"
+	labelDRPolicy                      = "ramendr.openshift.io/dr-policy"
+	placementLabel                     = "cluster.open-cluster-management.io/placement"
+	applicationSetKind                 = "ApplicationSet"
+	subscriptionKind                   = "Subscription"
+	drpcKind                           = "DRPlacementControl"
+	placementKind                      = "Placement"
+	requeueAfterSeconds                = time.Duration(30 * time.Second)
+	subscriptionAnnotation             = "apps.open-cluster-management.io/subscriptions"
+	ramenAPIVersion                    = "ramendr.openshift.io/v1alpha1"
+	drPolicyKind                       = "DRPolicy"
+	subscriptionAPIVersion             = "apps.open-cluster-management.io/v1"
+	clusterDecisionResourceIndexName   = "spec.generators.clusterDecisionResource.placement"
+	placementIndexName                 = "spec.placementRef.name"
+	lastAppDeploymentClusterAnnotation = "drplacementcontrol.ramendr.openshift.io/last-app-deployment-cluster"
 )
 
 type ProtectedApplicationViewReconciler struct {
@@ -107,8 +108,16 @@ func (r *ProtectedApplicationViewReconciler) getPrimaryClusterFromDRPC(drpc *ram
 
 	default:
 		// For other states (Deploying, Deployed, Initiating, etc.)
-		// Use PreferredDecision as the source of truth
-		return drpc.Status.PreferredDecision.ClusterName
+		// 1. PreferredDecision is the scheduler-confirmed cluster (authoritative).
+		// 2. last-app-deployment-cluster annotation is reliably set by ramen.
+		// 3. Spec.PreferredCluster is user intent (last resort, better than empty).
+		if drpc.Status.PreferredDecision.ClusterName != "" {
+			return drpc.Status.PreferredDecision.ClusterName
+		}
+		if cluster, ok := drpc.Annotations[lastAppDeploymentClusterAnnotation]; ok && cluster != "" {
+			return cluster
+		}
+		return drpc.Spec.PreferredCluster
 	}
 }
 

--- a/controllers/ramen/protectedapplicationsview_controller_test.go
+++ b/controllers/ramen/protectedapplicationsview_controller_test.go
@@ -757,3 +757,47 @@ func TestPAVReconcile_DeployedPrimaryCluster(t *testing.T) {
 			pavTestCluster1, updatedPAV.Status.DRInfo.PrimaryCluster)
 	}
 }
+
+func TestPAVReconcile_DeployedPrimaryClusterAnnotationFallback(t *testing.T) {
+	pav := createTestPAV()
+	drpc := createTestDRPCForPAV()
+	drpc.Annotations = map[string]string{
+		lastAppDeploymentClusterAnnotation: pavTestCluster1,
+	}
+	drpc.Spec.FailoverCluster = pavTestCluster2
+	drpc.Status.Phase = ramenv1alpha1.Deployed
+	// PreferredDecision.ClusterName is empty — simulates ramen not having populated it yet
+
+	placement := createTestPlacementForPAV()
+	drPolicy := createTestDRPolicyForPAV()
+	placementDecision := createTestPlacementDecisionForPAV()
+
+	r := getFakePAVReconciler(pav, drpc, placement, drPolicy, placementDecision)
+
+	ctx := context.TODO()
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      pavTestDRPCName,
+			Namespace: pavTestNamespace,
+		},
+	}
+
+	_, err := r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	updatedPAV := &multiclusterv1alpha1.ProtectedApplicationView{}
+	err = r.Get(ctx, types.NamespacedName{
+		Name:      pavTestDRPCName,
+		Namespace: pavTestNamespace,
+	}, updatedPAV)
+	if err != nil {
+		t.Fatalf("Failed to get PAV: %v", err)
+	}
+
+	if updatedPAV.Status.DRInfo.PrimaryCluster != pavTestCluster1 {
+		t.Errorf("Expected primary cluster %s (annotation fallback), got %s",
+			pavTestCluster1, updatedPAV.Status.DRInfo.PrimaryCluster)
+	}
+}


### PR DESCRIPTION
When DRPC phase is Deployed/Deploying/Initiating and Status.PreferredDecision.ClusterName is empty, fall back to the drplacementcontrol.ramendr.openshift.io/last-app-deployment-cluster annotation which ramen reliably sets, then to Spec.PreferredCluster as a last resort. This prevents the console from showing "-" in the Cluster column on the Protected Applications page.

https://redhat.atlassian.net/browse/DFBUGS-6502 - UI bug that ties to backend