### PR TITLE
DFBUGS-5480: [release-4.17] cve-fix: resolve CVE-2025-61726 in net/url

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.57.0
+        version: v1.64.8
 
   kube-linter:
     name: Kube YAML

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout source
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout source
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Checkout source

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.22' ]
+        go: [ '1.24' ]
     steps:
     - name: Checkout source
       uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.24 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,8 @@ ifeq ($(OPENSHIFT_CI), true)
 else
 	@echo "Running outside OpenShift CI. Ignoring vendor"
 endif
-	make manifests generate fmt vet
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./tests/integration/... -v -tags integration -coverprofile integration-cover.out
+	make manifests generate fmt vet setup-envtest
+	KUBEBUILDER_ASSETS=`$(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path` go test ./tests/integration/... -v -tags integration -coverprofile integration-cover.out
 
 ##@ Build
 

--- a/addons/manager.go
+++ b/addons/manager.go
@@ -259,7 +259,7 @@ func runSpokeManager(ctx context.Context, options AddonAgentOptions, logger *slo
 				var crd extv1.CustomResourceDefinition
 				readErr := mgr.GetAPIReader().Get(ctx, types.NamespacedName{Name: "maintenancemodes.ramendr.openshift.io"}, &crd)
 				if readErr != nil {
-					logger.Error("Unable to get MaintenanceMode CRD", readErr)
+					logger.Error("Unable to get MaintenanceMode CRD", "Error", readErr.Error())
 					// Do not initialize err as we want to retry.
 					// err!=nil or done==true will end polling.
 					done = false

--- a/addons/s3_controller.go
+++ b/addons/s3_controller.go
@@ -88,7 +88,7 @@ func (r *S3SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	err = r.syncBlueSecretForS3(ctx, obc.Name, obc.Namespace)
 	if err != nil {
-		logger.Error("Failed to sync Blue Secret for S3", "OBC", "error", err)
+		logger.Error("Failed to sync Blue Secret for S3", "error", err.Error())
 		return ctrl.Result{}, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/red-hat-storage/odf-multicluster-orchestrator
 
-go 1.22.0
+go 1.24.0
+
+toolchain go1.24.13
 
 require (
 	github.com/csi-addons/kubernetes-csi-addons v0.8.0
@@ -174,5 +176,4 @@ exclude (
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/client-go v12.0.0+incompatible
-
 )

--- a/hack/make/tools.mk
+++ b/hack/make/tools.mk
@@ -57,7 +57,7 @@ endif
 endif
 
 GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-GOLANGCI_VERSION := 1.57.0
+GOLANGCI_VERSION := 1.64.8
 
 .PHONY: golangci-bin
 GOLANGCI_BIN := $(CWD)/bin/golangci-lint

--- a/hack/make/tools.mk
+++ b/hack/make/tools.mk
@@ -1,3 +1,11 @@
+## Tool Binaries
+LOCALBIN ?= $(CWD)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+ENVTEST_VERSION ?= latest
+
 # go-get-tool will 'go get' any package $2 and install it to $1.
 define go-get-tool
 @[ -f $(1) ] || { \
@@ -74,3 +82,32 @@ endif
 KUBELINTER_BIN := $(CWD)/bin/kube-linter
 kubelinter-bin: ## Download kube-linter locally if necessary
 	$(call go-get-tool,$(KUBELINTER_BIN),golang.stackrox.io/kube-linter/cmd/kube-linter@0.2.2)
+
+.PHONY: setup-envtest
+setup-envtest: envtest ## Download the binaries required for ENVTEST in the local bin directory.
+	@echo "Setting up envtest binaries for Kubernetes version $(ENVTEST_K8S_VERSION)..."
+	@$(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path || { \
+		echo "Error: Failed to set up envtest binaries for version $(ENVTEST_K8S_VERSION)."; \
+		exit 1; \
+	}
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f "$(1)-$(3)" ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+rm -f $(1) || true ;\
+GOBIN=$(LOCALBIN) go install $${package} ;\
+mv $(1) $(1)-$(3) ;\
+} ;\
+ln -sf $(1)-$(3) $(1)
+endef

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package integration_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -46,6 +47,8 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var ctx context.Context
+var ctxCancel context.CancelFunc
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -54,6 +57,8 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	ctx, ctxCancel = context.WithCancel(ctrl.SetupSignalHandler())
+
 	var err error
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
@@ -115,7 +120,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {
-		err = mgr.Start(ctrl.SetupSignalHandler())
+		err = mgr.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
@@ -123,6 +128,7 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+	ctxCancel()
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
- Upgraded Go version from 1.23.10 to 1.24.13
- CVE-2025-61726: Memory exhaustion in query parameter parsing in net/url
- Vulnerability in net/url package when parsing URL-encoded forms with large numbers of query parameters can cause excessive memory consumption
- Severity: Important (Red Hat security rating)
- Updated go.mod: go 1.24.0, toolchain go1.24.13
- Updated Dockerfile: golang:1.24
- Updated GitHub workflows to use Go 1.24:
  - .github/workflows/lint.yaml
  - .github/workflows/publish-images.yaml
  - .github/workflows/test-and-build.yaml
- Update golangci-lint to 1.64.8 for Go 1.24 support
- While vulnerable code is not currently used in codebase, upgrading ensures protection against future code changes and provides access to other security fixes


(cherry picked from commit 540186d118f499041e633f8f62d6601801362f69)