### PR TITLE
fix: Register appv1beta1 scheme for PAV subscription status

### DIFF
--- a/controllers/manager.go
+++ b/controllers/manager.go
@@ -29,6 +29,7 @@ import (
 	placementv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	appsubapis "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
+	appv1beta1 "sigs.k8s.io/application/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -54,6 +55,7 @@ func init() {
 	utilruntime.Must(placementv1beta1.AddToScheme(mgrScheme))
 	utilruntime.Must(argov1alpha1.AddToScheme(mgrScheme))
 	utilruntime.Must(appsubapis.AddToScheme(mgrScheme))
+	utilruntime.Must(appv1beta1.AddToScheme(mgrScheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/controllers/ramen/protectedapplicationsview_controller.go
+++ b/controllers/ramen/protectedapplicationsview_controller.go
@@ -199,9 +199,13 @@ func (r *ProtectedApplicationViewReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{RequeueAfter: requeueAfterSeconds}, err
 	}
 	placement := &placementv1beta1.Placement{}
+	placementNS := drpc.Spec.PlacementRef.Namespace
+	if placementNS == "" {
+		placementNS = drpc.Namespace
+	}
 	placementKey := types.NamespacedName{
 		Name:      drpc.Spec.PlacementRef.Name,
-		Namespace: drpc.Spec.PlacementRef.Namespace,
+		Namespace: placementNS,
 	}
 	if err := r.Get(ctx, placementKey, placement); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -342,7 +346,6 @@ func (r *ProtectedApplicationViewReconciler) findApplicationForDRPC(
 		app, err := r.findParentApplication(ctx, subscriptions)
 		if err != nil {
 			logger.Error("Failed to find parent Application", "error", err)
-			return ApplicationResult{}, err
 		}
 
 		result := ApplicationResult{Type: multiclusterv1alpha1.SubscriptionType}

--- a/controllers/ramen/protectedapplicationsview_controller_test.go
+++ b/controllers/ramen/protectedapplicationsview_controller_test.go
@@ -5,7 +5,7 @@ package ramen
 
 import (
 	"context"
-	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -126,6 +126,22 @@ func TestPAVReconcile_Subscription(t *testing.T) {
 
 	if len(updatedPAV.Status.ApplicationInfo.SubscriptionInfo.SubscriptionRefs) != 1 {
 		t.Errorf("Expected 1 subscription ref, got %d", len(updatedPAV.Status.ApplicationInfo.SubscriptionInfo.SubscriptionRefs))
+	}
+
+	if updatedPAV.Status.DRInfo.DRPolicyRef.Name != pavTestDRPolicyName {
+		t.Errorf("Expected DRPolicyRef.Name %s, got %s", pavTestDRPolicyName, updatedPAV.Status.DRInfo.DRPolicyRef.Name)
+	}
+
+	if len(updatedPAV.Status.DRInfo.DRClusters) != 2 {
+		t.Errorf("Expected 2 DRClusters, got %d", len(updatedPAV.Status.DRInfo.DRClusters))
+	}
+
+	if updatedPAV.Status.DRInfo.Status.Phase != ramenv1alpha1.Deployed {
+		t.Errorf("Expected phase %s, got %s", ramenv1alpha1.Deployed, updatedPAV.Status.DRInfo.Status.Phase)
+	}
+
+	if !reflect.DeepEqual(updatedPAV.Status.DRInfo.ProtectedNamespaces, []string{"app-namespace"}) {
+		t.Errorf("Expected ProtectedNamespaces [app-namespace], got %v", updatedPAV.Status.DRInfo.ProtectedNamespaces)
 	}
 }
 
@@ -557,10 +573,6 @@ func createTestPlacementDecisionForPAV() *placementv1beta1.PlacementDecision {
 
 func getFakePAVReconciler(objects ...client.Object) *ProtectedApplicationViewReconciler {
 	scheme := mgrScheme
-
-	if err := appv1beta1.AddToScheme(scheme); err != nil {
-		panic(fmt.Sprintf("Failed to add Application scheme: %v", err))
-	}
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/controllers/testutil/scheme.go
+++ b/controllers/testutil/scheme.go
@@ -27,6 +27,7 @@ import (
 	placementv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	appsubapis "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
+	appv1beta1 "sigs.k8s.io/application/api/v1beta1"
 )
 
 var TestScheme = func() *runtime.Scheme {
@@ -42,6 +43,7 @@ var TestScheme = func() *runtime.Scheme {
 	utilruntime.Must(placementv1beta1.AddToScheme(s))
 	utilruntime.Must(argov1alpha1.AddToScheme(s))
 	utilruntime.Must(appsubapis.AddToScheme(s))
+	utilruntime.Must(appv1beta1.AddToScheme(s))
 	utilruntime.Must(replicationv1alpha1.AddToScheme(s))
 	utilruntime.Must(ocsv1.AddToScheme(s))
 	utilruntime.Must(ocsv1alpha1.AddToScheme(s))


### PR DESCRIPTION
Bug: https://redhat.atlassian.net/browse/DFBUGS-6967

## Summary
- `appv1beta1.ApplicationList` was not registered in the manager runtime scheme (`controllers/manager.go`), causing `findParentApplication` to fail with `"no kind is registered for the type v1beta1.ApplicationList"` for subscription-based apps
- This made `Reconcile` return before reaching `updatePAVStatus`, leaving DRPolicy and Cluster columns empty in the ODF console for managed (subscription) apps
- Made `findParentApplication` errors non-fatal so DRInfo is still populated even if the Application CRD listing fails
- Removed local `appv1beta1.AddToScheme` from test helper that was masking the production bug
- Added DRInfo assertions to `TestPAVReconcile_Subscription`

## Root Cause
Production logs showed:
```
"no kind is registered for the type v1beta1.ApplicationList in scheme \"pkg/runtime/scheme.go:110\""
```
The `sigs.k8s.io/application/api/v1beta1` package was imported and used by the PAV controller but never registered in `mgrScheme`. Tests passed because `getFakePAVReconciler` added it locally via `appv1beta1.AddToScheme(scheme)`.

