### PR TITLE
fix: preserve unknown fields in ramen hub operator configmap updates

### DIFF
--- a/controllers/ramen/ramen_test.go
+++ b/controllers/ramen/ramen_test.go
@@ -310,6 +310,62 @@ func createOrUpdateSecretsFromInternalSecret(ctx context.Context, rc client.Clie
 	return utils.UpdateRamenHubOperatorConfig(ctx, rc, secret, data, mirrorPeer, currentNamespace, logger)
 }
 
+func TestUpdateRamenConfigPreservesUnknownFields(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = multiclusterv1alpha1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	configYAML := `retainNamespaceSCCAcrossPeers: true
+volumeUnprotectionEnabled: true
+ramenOpsNamespace: ramen-ops
+maxConcurrentReconciles: 10
+`
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      utils.RamenHubOperatorConfigName,
+				Namespace: ramenNamespace,
+			},
+			Data: map[string]string{
+				"ramen_manager_config.yaml": configYAML,
+			},
+		},
+	).Build()
+
+	fakeLogger := utils.GetLogger(utils.GetZapLogger(true))
+	ctx := context.TODO()
+	os.Setenv("POD_NAMESPACE", ramenNamespace)
+
+	err = createOrUpdateSecretsFromInternalSecret(
+		ctx, fakeClient, scheme, ramenNamespace,
+		fakeS3InternalSecret(t, TestSourceManagedClusterEast),
+		fakeMirrorPeers(true), fakeLogger,
+	)
+	assert.NoError(t, err)
+
+	updatedCM := corev1.ConfigMap{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      utils.RamenHubOperatorConfigName,
+		Namespace: ramenNamespace,
+	}, &updatedCM)
+	assert.NoError(t, err)
+
+	var rawConfig map[string]interface{}
+	err = yaml.Unmarshal([]byte(updatedCM.Data["ramen_manager_config.yaml"]), &rawConfig)
+	assert.NoError(t, err)
+
+	assert.Equal(t, true, rawConfig["retainNamespaceSCCAcrossPeers"],
+		"retainNamespaceSCCAcrossPeers must survive the update")
+	assert.Equal(t, true, rawConfig["volumeUnprotectionEnabled"],
+		"volumeUnprotectionEnabled must survive the update")
+	assert.Equal(t, "ramen-ops", rawConfig["ramenOpsNamespace"],
+		"ramenOpsNamespace must survive the update")
+	assert.NotNil(t, rawConfig["s3StoreProfiles"],
+		"s3StoreProfiles must be present after the update")
+}
+
 func TestCreateOrUpdateSecretsFromInternalSecret(t *testing.T) {
 	cases := []struct {
 		name            string

--- a/controllers/utils/ramen.go
+++ b/controllers/utils/ramen.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -103,22 +104,30 @@ func UpdateRamenHubOperatorConfig(ctx context.Context, rc client.Client, secret 
 		return err
 	}
 
-	ramenConfig := rmn.RamenConfig{}
-	err = yaml.Unmarshal([]byte(ramenConfigData), &ramenConfig)
-	if err != nil {
+	// Unmarshal into an unstructured map so that fields unknown to our
+	// version of the RamenConfig struct are preserved across the
+	// read-modify-write cycle.
+	rawConfig := map[string]interface{}{}
+	if err := yaml.Unmarshal([]byte(ramenConfigData), &rawConfig); err != nil {
 		logger.Error("Failed to unmarshal DR hub operator config data", "error", err)
 		return err
 	}
 
+	existingProfiles, err := extractS3Profiles(rawConfig)
+	if err != nil {
+		logger.Error("Failed to extract S3 profiles from config", "error", err)
+		return err
+	}
+
 	isUpdated := false
-	for i, currentS3Profile := range ramenConfig.S3StoreProfiles {
+	for i, currentS3Profile := range existingProfiles {
 		if currentS3Profile.S3ProfileName == expectedS3Profile.S3ProfileName {
 			mergeCustomS3ProfileFields(&currentS3Profile, &expectedS3Profile)
 			if areS3ProfileFieldsEqual(expectedS3Profile, currentS3Profile) {
 				logger.Info("No change detected in S3 profile, skipping update", "S3ProfileName", expectedS3Profile.S3ProfileName)
 				return nil
 			}
-			updateS3ProfileFields(&expectedS3Profile, &ramenConfig.S3StoreProfiles[i])
+			updateS3ProfileFields(&expectedS3Profile, &existingProfiles[i])
 			isUpdated = true
 			logger.Info("S3 profile updated", "S3ProfileName", expectedS3Profile.S3ProfileName)
 			break
@@ -126,11 +135,16 @@ func UpdateRamenHubOperatorConfig(ctx context.Context, rc client.Client, secret 
 	}
 
 	if !isUpdated {
-		ramenConfig.S3StoreProfiles = append(ramenConfig.S3StoreProfiles, expectedS3Profile)
+		existingProfiles = append(existingProfiles, expectedS3Profile)
 		logger.Info("New S3 profile added", "S3ProfileName", expectedS3Profile.S3ProfileName)
 	}
 
-	ramenConfigDataStr, err := yaml.Marshal(ramenConfig)
+	if err := setS3Profiles(rawConfig, existingProfiles); err != nil {
+		logger.Error("Failed to set S3 profiles in config", "error", err)
+		return err
+	}
+
+	ramenConfigDataStr, err := yaml.Marshal(rawConfig)
 	if err != nil {
 		logger.Error("Failed to marshal Ramen config", "error", err)
 		return err
@@ -146,5 +160,43 @@ func UpdateRamenHubOperatorConfig(ctx context.Context, rc client.Client, secret 
 	}
 
 	logger.Info("Ramen Hub Operator config updated successfully", "ConfigMapName", namespacedName)
+	return nil
+}
+
+// extractS3Profiles reads the s3StoreProfiles key from an unstructured config
+// map and returns typed S3StoreProfile values.
+func extractS3Profiles(rawConfig map[string]interface{}) ([]rmn.S3StoreProfile, error) {
+	raw, ok := rawConfig["s3StoreProfiles"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+
+	jsonBytes, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal s3StoreProfiles to JSON: %w", err)
+	}
+
+	var profiles []rmn.S3StoreProfile
+	if err := json.Unmarshal(jsonBytes, &profiles); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal s3StoreProfiles from JSON: %w", err)
+	}
+
+	return profiles, nil
+}
+
+// setS3Profiles writes the given S3StoreProfile slice back into the
+// unstructured config map under the s3StoreProfiles key.
+func setS3Profiles(rawConfig map[string]interface{}, profiles []rmn.S3StoreProfile) error {
+	jsonBytes, err := json.Marshal(profiles)
+	if err != nil {
+		return fmt.Errorf("failed to marshal s3StoreProfiles to JSON: %w", err)
+	}
+
+	var raw interface{}
+	if err := json.Unmarshal(jsonBytes, &raw); err != nil {
+		return fmt.Errorf("failed to unmarshal s3StoreProfiles from JSON: %w", err)
+	}
+
+	rawConfig["s3StoreProfiles"] = raw
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/openshift/api v0.0.0-20251120040117-916c7003ed78
 	github.com/openshift/library-go v0.0.0-20240124134907-4dfbf6bc7b11
-	github.com/ramendr/ramen/api v0.0.0-20260113215613-3749cae33639
+	github.com/ramendr/ramen/api v0.0.0-20260609143232-8539a3642b6e
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20260113064915-e9473b4e5f1a
 	github.com/rook/rook/pkg/apis v0.0.0-20260113214458-a712afae9805
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -990,8 +990,8 @@ github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/r3labs/diff/v3 v3.0.2 h1:yVuxAY1V6MeM4+HNur92xkS39kB/N+cFi2hMkY06BbA=
 github.com/r3labs/diff/v3 v3.0.2/go.mod h1:Cy542hv0BAEmhDYWtGxXRQ4kqRsVIcEjG9gChUlTmkw=
-github.com/ramendr/ramen/api v0.0.0-20260113215613-3749cae33639 h1:QObLDV4PRTxdkSXxPGaLNPk2qFC/Tp5vy2XPRI18u4o=
-github.com/ramendr/ramen/api v0.0.0-20260113215613-3749cae33639/go.mod h1:G3q4wmHUdOVefjCKSacg3McDodLwtfFe84wSrGxQ69w=
+github.com/ramendr/ramen/api v0.0.0-20260609143232-8539a3642b6e h1:PNYx+wTSAoRo5THxe1qvyNuiQ9T3/DT+5aash0rI21E=
+github.com/ramendr/ramen/api v0.0.0-20260609143232-8539a3642b6e/go.mod h1:F6Iuq5ywxI4TJL2VvoJNQvn2cMWOHOdysbaoeT9RMig=
 github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20260113064915-e9473b4e5f1a h1:FeRvfblz8THny6ShCPxCDmKu8rKmbF348f1FtPvTKhk=
 github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20260113064915-e9473b4e5f1a/go.mod h1:Lkfm/UaH1hPkjLjXf4g2elAaGspLzmHXwgGSIkeNzf4=
 github.com/redis/go-redis/v9 v9.0.0-rc.4/go.mod h1:Vo3EsyWnicKnSKCA7HhgnvnyA74wOA69Cd2Meli5mmA=


### PR DESCRIPTION
## Summary

- `updateRamenHubOperatorConfig()` performs a full unmarshal→marshal round-trip on the `ramen-hub-operator-config` ConfigMap using a typed `RamenConfig` struct. Because odf-multicluster-orchestrator pins the ramen API at a version that predates newer fields (e.g. `RetainNamespaceSCCAcrossPeers` added in ramen April 2026), the round-trip silently strips those fields from the ConfigMap whenever MirrorPeer reconciliation updates S3 profiles.
- Switched to `map[string]interface{}` for the YAML round-trip, extracting only the `s3StoreProfiles` key for typed manipulation via `extractS3Profiles()` and `setS3Profiles()` helpers. This preserves all unknown fields regardless of API version skew.
- Added `TestUpdateRamenConfigPreservesUnknownFields` to verify that fields not present in the current `RamenConfig` struct survive an S3 profile update.

## Test plan

- [x] Existing unit tests pass (`go test -tags unit ./controllers/utils/`)
- [x] New test `TestUpdateRamenConfigPreservesUnknownFields` validates unknown fields survive the round-trip
- [x] `go build ./...` succeeds
- [ ] Manual verification in a cluster with a ramen configmap containing `retainNamespaceSCCAcrossPeers: true`, creating a DRPolicy and confirming the field is not stripped