### PR TITLE
DFBUGS-7384: [release-4.21] fix: dynamically set ConsolePlugin basePath based on OCP version

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -162,6 +162,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - console.openshift.io
   resources:
   - consoleplugins

--- a/console/console.go
+++ b/console/console.go
@@ -14,23 +14,22 @@ limitations under the License.
 package console
 
 import (
-	"context"
 	"fmt"
+	"strings"
 
 	consolev1 "github.com/openshift/api/console/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	MAIN_BASE_PATH          = "/"
+	COMPATIBILITY_BASE_PATH = "/compatibility/"
+	PluginName              = "odf-multicluster-console"
 )
 
 var (
-	odfMulticlusterPluginName = "odf-multicluster-console"
-	pluginBasePath            = "/"
-
 	proxyAlias            = "acm-thanos-querier"
 	proxyServiceName      = "rbac-query-proxy"
 	proxyServiceNamespace = "open-cluster-management-observability"
@@ -42,7 +41,7 @@ var (
 	serviceLabelKey         = "app.kubernetes.io/name"
 )
 
-func getService(serviceName string, port int, deploymentNamespace string) apiv1.Service {
+func GetService(serviceName string, port int, deploymentNamespace string) apiv1.Service {
 	return apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
@@ -51,7 +50,7 @@ func getService(serviceName string, port int, deploymentNamespace string) apiv1.
 				serviceSecretAnnotation: fmt.Sprintf("%s-serving-cert", serviceName),
 			},
 			Labels: map[string]string{
-				serviceLabelKey: odfMulticlusterPluginName,
+				serviceLabelKey: PluginName,
 			},
 		},
 		Spec: apiv1.ServiceSpec{
@@ -64,16 +63,16 @@ func getService(serviceName string, port int, deploymentNamespace string) apiv1.
 				},
 			},
 			Selector: map[string]string{
-				serviceLabelKey: odfMulticlusterPluginName,
+				serviceLabelKey: PluginName,
 			},
 		},
 	}
 }
 
-func getConsolePluginCR(consolePort int, serviceName string, deploymentNamespace string) consolev1.ConsolePlugin {
+func GetConsolePluginCR(consolePort int, serviceName string, deploymentNamespace string) consolev1.ConsolePlugin {
 	return consolev1.ConsolePlugin{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: odfMulticlusterPluginName,
+			Name: PluginName,
 		},
 		Spec: consolev1.ConsolePluginSpec{
 			DisplayName: pluginDisplayName,
@@ -82,7 +81,7 @@ func getConsolePluginCR(consolePort int, serviceName string, deploymentNamespace
 					Name:      serviceName,
 					Namespace: deploymentNamespace,
 					Port:      int32(consolePort),
-					BasePath:  pluginBasePath,
+					BasePath:  MAIN_BASE_PATH,
 				},
 				Type: consolev1.Service,
 			},
@@ -104,28 +103,10 @@ func getConsolePluginCR(consolePort int, serviceName string, deploymentNamespace
 	}
 }
 
-func InitConsole(ctx context.Context, client client.Client, odfPort int, deploymentNamespace string) error {
-	deployment := appsv1.Deployment{}
-	if err := client.Get(context.TODO(), types.NamespacedName{
-		Name:      odfMulticlusterPluginName,
-		Namespace: deploymentNamespace,
-	}, &deployment); err != nil {
-		return err
-	}
-	// Create core ODF multicluster console service
-	odfService := getService(odfMulticlusterPluginName, odfPort, deploymentNamespace)
-	if _, err := controllerutil.CreateOrUpdate(ctx, client, &odfService, func() error {
-		return nil
-	}); err != nil {
-		return err
-	}
-	// Create core ODF multicluster plugin
-	odfConsolePlugin := getConsolePluginCR(odfPort, odfService.ObjectMeta.Name, deploymentNamespace)
-	if _, err := controllerutil.CreateOrUpdate(ctx, client, &odfConsolePlugin, func() error {
-		return nil
-	}); err != nil {
-		return err
+func GetBasePath(clusterVersion string) string {
+	if strings.Contains(clusterVersion, "4.22") {
+		return COMPATIBILITY_BASE_PATH
 	}
 
-	return nil
+	return MAIN_BASE_PATH
 }

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -1,144 +1,42 @@
 package console
 
 import (
-	"context"
-	"reflect"
 	"testing"
 
-	consolev1 "github.com/openshift/api/console/v1"
-	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
-	apiv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var (
-	testMulticlusterNamespace = "test_multicluster_ns"
-	testPort                  = 9003
-)
-
-type testCase struct {
-	name        string
-	port        int
-	namespace   string
-	errExpected bool
-}
-
-func getExpectedConsolePluginSpec() consolev1.ConsolePluginSpec {
-	return consolev1.ConsolePluginSpec{
-		DisplayName: pluginDisplayName,
-		Backend: consolev1.ConsolePluginBackend{
-			Service: &consolev1.ConsolePluginService{
-				Name:      odfMulticlusterPluginName,
-				Namespace: testMulticlusterNamespace,
-				Port:      int32(testPort),
-				BasePath:  pluginBasePath,
-			},
-			Type: consolev1.Service,
-		},
-		Proxy: []consolev1.ConsolePluginProxy{
-			{
-				Alias:         proxyAlias,
-				Authorization: consolev1.UserToken,
-				Endpoint: consolev1.ConsolePluginProxyEndpoint{
-					Type: consolev1.ProxyTypeService,
-					Service: &consolev1.ConsolePluginProxyServiceConfig{
-						Name:      proxyServiceName,
-						Namespace: proxyServiceNamespace,
-						Port:      int32(proxyServicePort),
-					},
-				},
-			},
-		},
-	}
-}
-
-func getExpectedServiceSpec() apiv1.ServiceSpec {
-	return apiv1.ServiceSpec{
-		Ports: []apiv1.ServicePort{
-			{
-				Protocol:   apiv1.ProtocolTCP,
-				TargetPort: intstr.IntOrString{IntVal: int32(testPort)},
-				Port:       int32(testPort),
-				Name:       servicePortName,
-			},
-		},
-		Selector: map[string]string{
-			serviceLabelKey: odfMulticlusterPluginName,
-		},
-	}
-}
-
-func createFakeScheme(t *testing.T) *runtime.Scheme {
-	scheme, err := multiclusterv1alpha1.SchemeBuilder.Build()
-	if err != nil {
-		assert.Fail(t, "unable to build scheme")
-	}
-	err = appsv1.AddToScheme(scheme)
-	if err != nil {
-		assert.Fail(t, "failed to add appsv1 scheme")
-	}
-	err = consolev1.AddToScheme(scheme)
-	if err != nil {
-		assert.Fail(t, "failed to add consolev1 scheme")
-	}
-	err = apiv1.AddToScheme(scheme)
-	if err != nil {
-		assert.Fail(t, "failed to add apiv1 scheme")
-	}
-
-	return scheme
-}
-
-func TestInitConsole(t *testing.T) {
-	cases := []testCase{
+func TestGetBasePath(t *testing.T) {
+	cases := []struct {
+		name             string
+		clusterVersion   string
+		expectedBasePath string
+	}{
 		{
-			name:        "multicluster console deployment not found",
-			namespace:   "wrong_ns",
-			port:        testPort,
-			errExpected: true,
+			name:             "OCP 4.21 should use main base path",
+			clusterVersion:   "4.21.3",
+			expectedBasePath: MAIN_BASE_PATH,
 		},
 		{
-			name:        "successfully deployed multicluster plugin",
-			namespace:   testMulticlusterNamespace,
-			port:        testPort,
-			errExpected: false,
+			name:             "OCP 4.20 should use main base path",
+			clusterVersion:   "4.20.5",
+			expectedBasePath: MAIN_BASE_PATH,
+		},
+		{
+			name:             "OCP 4.22 should use compatibility base path",
+			clusterVersion:   "4.22.0",
+			expectedBasePath: COMPATIBILITY_BASE_PATH,
+		},
+		{
+			name:             "OCP 4.22 nightly should use compatibility base path",
+			clusterVersion:   "4.22.0-0.nightly-2026-05-28-111510",
+			expectedBasePath: COMPATIBILITY_BASE_PATH,
 		},
 	}
-	obj := appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      odfMulticlusterPluginName,
-			Namespace: testMulticlusterNamespace,
-		},
-	}
-	scheme := createFakeScheme(t)
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&obj).Build()
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := InitConsole(context.TODO(), client, c.port, c.namespace)
-			if c.errExpected {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				consolePlugin := consolev1.ConsolePlugin{}
-				err := client.Get(context.TODO(), types.NamespacedName{
-					Name: odfMulticlusterPluginName,
-				}, &consolePlugin)
-				assert.NoError(t, err)
-				assert.True(t, reflect.DeepEqual(getExpectedConsolePluginSpec(), consolePlugin.Spec))
-				service := apiv1.Service{}
-				err = client.Get(context.TODO(), types.NamespacedName{
-					Name:      odfMulticlusterPluginName,
-					Namespace: testMulticlusterNamespace,
-				}, &service)
-				assert.NoError(t, err)
-				assert.True(t, reflect.DeepEqual(getExpectedServiceSpec(), service.Spec))
-			}
+			result := GetBasePath(c.clusterVersion)
+			assert.Equal(t, c.expectedBasePath, result)
 		})
 	}
 }

--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 Red Hat Data Foundation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"log/slog"
+
+	configv1 "github.com/openshift/api/config/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/console"
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/utils"
+)
+
+type ClusterVersionReconciler struct {
+	client.Client
+	Scheme            *runtime.Scheme
+	Logger            *slog.Logger
+	ConsolePort       int
+	OperatorNamespace string
+}
+
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;update
+// +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update
+
+func (r *ClusterVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ocpVersion, err := utils.GetOpenShiftVersion(ctx, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.ensureConsolePlugin(ctx, ocpVersion); err != nil {
+		r.Logger.Error("Could not ensure compatibility for odf-multicluster-console plugin", "error", err)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClusterVersionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		clusterVersion, err := utils.GetOpenShiftVersion(ctx, r.Client)
+		if err != nil {
+			return err
+		}
+
+		return r.ensureConsolePlugin(ctx, clusterVersion)
+	}))
+	if err != nil {
+		return err
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&configv1.ClusterVersion{}).
+		Complete(r)
+}
+
+func (r *ClusterVersionReconciler) ensureConsolePlugin(ctx context.Context, clusterVersion string) error {
+	basePath := console.GetBasePath(clusterVersion)
+
+	deployment := appsv1.Deployment{}
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      console.PluginName,
+		Namespace: r.OperatorNamespace,
+	}, &deployment); err != nil {
+		return err
+	}
+
+	odfService := console.GetService(console.PluginName, r.ConsolePort, r.OperatorNamespace)
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &odfService, func() error {
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	odfConsolePlugin := console.GetConsolePluginCR(r.ConsolePort, console.PluginName, r.OperatorNamespace)
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &odfConsolePlugin, func() error {
+		if odfConsolePlugin.Spec.Backend.Service != nil && odfConsolePlugin.Spec.Backend.Service.BasePath != basePath {
+			r.Logger.Info(fmt.Sprintf("Set the BasePath for odf-multicluster-console plugin as '%s'", basePath))
+			odfConsolePlugin.Spec.Backend.Service.BasePath = basePath
+		}
+		return nil
+	})
+	return err
+}

--- a/controllers/clusterversion_controller_test.go
+++ b/controllers/clusterversion_controller_test.go
@@ -1,0 +1,118 @@
+package controllers
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	consolev1 "github.com/openshift/api/console/v1"
+	"github.com/red-hat-storage/odf-multicluster-orchestrator/console"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(configv1.AddToScheme(s))
+	utilruntime.Must(consolev1.AddToScheme(s))
+	utilruntime.Must(appsv1.AddToScheme(s))
+	utilruntime.Must(corev1.AddToScheme(s))
+	return s
+}
+
+func TestEnsureConsolePlugin(t *testing.T) {
+	testNamespace := "openshift-operators"
+	testPort := 9001
+
+	cases := []struct {
+		name             string
+		clusterVersion   string
+		expectedBasePath string
+	}{
+		{
+			name:             "OCP 4.21 sets main base path",
+			clusterVersion:   "4.21.3",
+			expectedBasePath: console.MAIN_BASE_PATH,
+		},
+		{
+			name:             "OCP 4.22 nightly sets compatibility base path",
+			clusterVersion:   "4.22.0-0.nightly-2026-06-14-141125",
+			expectedBasePath: console.COMPATIBILITY_BASE_PATH,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      console.PluginName,
+					Namespace: testNamespace,
+				},
+			}
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+
+			r := &ClusterVersionReconciler{
+				Client:            client,
+				Scheme:            scheme,
+				Logger:            slog.Default(),
+				ConsolePort:       testPort,
+				OperatorNamespace: testNamespace,
+			}
+
+			err := r.ensureConsolePlugin(context.TODO(), c.clusterVersion)
+			assert.NoError(t, err)
+
+			plugin := &consolev1.ConsolePlugin{}
+			err = client.Get(context.TODO(), types.NamespacedName{Name: console.PluginName}, plugin)
+			assert.NoError(t, err)
+			assert.Equal(t, c.expectedBasePath, plugin.Spec.Backend.Service.BasePath)
+		})
+	}
+}
+
+func TestEnsureConsolePluginUpdatesBasePath(t *testing.T) {
+	testNamespace := "openshift-operators"
+	testPort := 9001
+	scheme := newTestScheme()
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      console.PluginName,
+			Namespace: testNamespace,
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+
+	r := &ClusterVersionReconciler{
+		Client:            client,
+		Scheme:            scheme,
+		Logger:            slog.Default(),
+		ConsolePort:       testPort,
+		OperatorNamespace: testNamespace,
+	}
+
+	// First call with OCP 4.21 — main path
+	err := r.ensureConsolePlugin(context.TODO(), "4.21.3")
+	assert.NoError(t, err)
+
+	plugin := &consolev1.ConsolePlugin{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: console.PluginName}, plugin)
+	assert.NoError(t, err)
+	assert.Equal(t, console.MAIN_BASE_PATH, plugin.Spec.Backend.Service.BasePath)
+
+	// Second call with OCP 4.22 - should update to compatibility path
+	err = r.ensureConsolePlugin(context.TODO(), "4.22.0-0.nightly-2026-06-14-141125")
+	assert.NoError(t, err)
+
+	err = client.Get(context.TODO(), types.NamespacedName{Name: console.PluginName}, plugin)
+	assert.NoError(t, err)
+	assert.Equal(t, console.COMPATIBILITY_BASE_PATH, plugin.Spec.Backend.Service.BasePath)
+}

--- a/controllers/manager.go
+++ b/controllers/manager.go
@@ -7,11 +7,11 @@ import (
 
 	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/go-logr/zapr"
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	ramenv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/addons/setup"
 	multiclusterv1alpha1 "github.com/red-hat-storage/odf-multicluster-orchestrator/api/v1alpha1"
-	"github.com/red-hat-storage/odf-multicluster-orchestrator/console"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/controllers/utils"
 	"github.com/red-hat-storage/odf-multicluster-orchestrator/version"
 	"github.com/spf13/cobra"
@@ -28,7 +28,6 @@ import (
 	appsubapis "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
@@ -44,6 +43,7 @@ func init() {
 	utilruntime.Must(multiclusterv1alpha1.AddToScheme(mgrScheme))
 	utilruntime.Must(addonapiv1alpha1.AddToScheme(mgrScheme))
 	utilruntime.Must(consolev1.AddToScheme(mgrScheme))
+	utilruntime.Must(configv1.AddToScheme(mgrScheme))
 
 	utilruntime.Must(ramenv1alpha1.AddToScheme(mgrScheme))
 	utilruntime.Must(workv1.AddToScheme(mgrScheme))
@@ -195,15 +195,14 @@ func (o *ManagerOptions) runManager(ctx context.Context) {
 		os.Exit(1)
 	}
 
-	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		err = console.InitConsole(ctx, mgr.GetClient(), o.MulticlusterConsolePort, currentNamespace)
-		if err != nil {
-			logger.Error("Failed to initialize multicluster console to manager", "error", err)
-			return err
-		}
-		return nil
-	})); err != nil {
-		logger.Error("Failed to add multicluster console to manager", "error", err)
+	if err = (&ClusterVersionReconciler{
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Logger:            logger.With("controller", "ClusterVersionReconciler"),
+		ConsolePort:       o.MulticlusterConsolePort,
+		OperatorNamespace: currentNamespace,
+	}).SetupWithManager(mgr); err != nil {
+		logger.Error("Failed to create ClusterVersion controller", "error", err)
 		os.Exit(1)
 	}
 

--- a/controllers/utils/openshift.go
+++ b/controllers/utils/openshift.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetOpenShiftVersion(ctx context.Context, cl client.Client) (string, error) {
+	clusterVersion := &configv1.ClusterVersion{}
+	clusterVersion.Name = "version"
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(clusterVersion), clusterVersion); err != nil {
+		return "", err
+	}
+
+	for _, historyEntry := range clusterVersion.Status.History {
+		if historyEntry.State == configv1.CompletedUpdate {
+			return historyEntry.Version, nil
+		}
+	}
+
+	return "", fmt.Errorf("no completed version found in clusterVersion status history")
+}

--- a/controllers/utils/openshift_test.go
+++ b/controllers/utils/openshift_test.go
@@ -1,0 +1,90 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetOpenShiftVersion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := configv1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	cases := []struct {
+		name            string
+		clusterVersion  *configv1.ClusterVersion
+		expectedVersion string
+		errExpected     bool
+	}{
+		{
+			name: "returns completed version from history",
+			clusterVersion: &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{State: configv1.CompletedUpdate, Version: "4.22.0-0.nightly-2026-06-14-141125"},
+					},
+				},
+			},
+			expectedVersion: "4.22.0-0.nightly-2026-06-14-141125",
+			errExpected:     false,
+		},
+		{
+			name: "returns first completed version when upgrade is in progress",
+			clusterVersion: &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{State: configv1.PartialUpdate, Version: "4.22.0-0.nightly-2026-06-14-141125"},
+						{State: configv1.CompletedUpdate, Version: "4.21.3"},
+					},
+				},
+			},
+			expectedVersion: "4.21.3",
+			errExpected:     false,
+		},
+		{
+			name: "returns error when no completed version in history",
+			clusterVersion: &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{State: configv1.PartialUpdate, Version: "4.22.0"},
+					},
+				},
+			},
+			expectedVersion: "",
+			errExpected:     true,
+		},
+		{
+			name:            "returns error when clusterversion object not found",
+			clusterVersion:  nil,
+			expectedVersion: "",
+			errExpected:     true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if c.clusterVersion != nil {
+				builder = builder.WithObjects(c.clusterVersion)
+			}
+			client := builder.Build()
+
+			version, err := GetOpenShiftVersion(context.TODO(), client)
+			if c.errExpected {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, c.expectedVersion, version)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Detect the running OCP version from ClusterVersion CR and set the odf-multicluster-console ConsolePlugin basePath to /compatibility/ when running on OCP 4.22. This enables the console plugin to serve PatternFly-compatible assets matching the OCP console version.

Adds a ClusterVersionReconciler that watches ClusterVersion changes and ensures the ConsolePlugin CR basePath is updated accordingly.

Fixes: [DFBUGS-7384](https://redhat.atlassian.net/browse/DFBUGS-7384)