### PR TITLE
[main] Bump go (stdlib) from 1.25.5 to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-multicluster-orchestrator
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/argoproj/argo-cd/v3 v3.3.10


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.25.5` → `1.25.6` (in `go.mod`)
