### PR TITLE
[release-4.16] Bump go (stdlib) from 1.21 to 1.21.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-multicluster-orchestrator
 
-go 1.21
+go 1.21.13
 
 require (
 	github.com/csi-addons/kubernetes-csi-addons v0.8.0
@@ -170,5 +170,4 @@ exclude (
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/client-go v12.0.0+incompatible
-
 )


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.21` → `1.21.13` (in `go.mod`)
