### PR TITLE
[release-4.20] Bump go (stdlib) from 1.24.8 to 1.24.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-multicluster-orchestrator
 
-go 1.24.8
+go 1.24.11
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.8` → `1.24.11` (in `go.mod`)
