### PR TITLE
manifests: pin ODF-MCO workloads to restricted-v2 SCC

### DIFF
--- a/addons/setup/tokenexchange-manifests/spoke_deployment.yaml
+++ b/addons/setup/tokenexchange-manifests/spoke_deployment.yaml
@@ -12,6 +12,8 @@ spec:
       app: token-exchange-agent
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         app: token-exchange-agent
     spec:

--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -7,6 +7,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: odf-multicluster-console
   template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       automountServiceAccountToken: false
       containers:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION
Pin every ODF Multicluster Orchestrator pod template to an explicit Security Context Constraint using the openshift.io/required-scc annotation. This makes SCC assignment deterministic for audit and compliance in FSI/regulated environments, instead of relying on OpenShift admission to select the most permissive matching SCC at runtime.

Epic: [RHSTOR-8757](https://redhat.atlassian.net/browse/RHSTOR-8757) — Enforce least-privileged SCC across ODF pods
Workload | Manifest | SCC | Deploy path
-- | -- | -- | --
odfmo-controller-manager | config/manager/manager.yaml | restricted-v2 | OLM CSV (hub)
odf-multicluster-console | config/console/console_init.yaml | restricted-v2 | OLM CSV (hub)
token-exchange-agent | addons/setup/tokenexchange-manifests/spoke_deployment.yaml | restricted-v2 | ACM ManifestWork (spoke)

