### PR TITLE
Revert "[release-4.21] Bump go (stdlib) from 1.25.6 to 1.25.10"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-multicluster-orchestrator
 
-go 1.25.10
+go 1.25.6
 
 require (
 	github.com/argoproj/argo-cd/v3 v3.3.10


### PR DESCRIPTION
Reverts red-hat-storage/odf-multicluster-orchestrator#468