### PR TITLE
console: use s2i/run check instead of symlink detection

### DIFF
--- a/config/console/console_init.yaml
+++ b/config/console/console_init.yaml
@@ -16,8 +16,6 @@ spec:
             - /bin/sh
             - -c
             - |
-              CONF=/opt/app-root/etc/nginx.d/nginx.conf
-
               (
                 echo "Waiting for Nginx master process to start."
                 until nginx -s reload > /dev/null 2>&1; do
@@ -38,10 +36,10 @@ spec:
                 done
               ) &
 
-              if [ -L /etc/nginx/nginx.conf ]; then
+              if [ -x /usr/libexec/s2i/run ]; then
                 exec /usr/libexec/s2i/run
               else
-                exec nginx -c $CONF -g "daemon off;"
+                exec nginx -g "daemon off;"
               fi
           resources:
             limits:


### PR DESCRIPTION
Use -x to check if /usr/libexec/s2i/run is executable instead of -L to detect a symlink at /etc/nginx/nginx.conf. Also remove the -c flag from the nginx fallback to align with the client-console approach.

Ref: [RHSTOR-8685](https://redhat.atlassian.net/browse/RHSTOR-8685)