### PR TITLE
RHSTOR-8737: Reconcile multicluster console network policy

### DIFF
--- a/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-multicluster-orchestrator.clusterserviceversion.yaml
@@ -279,6 +279,14 @@ spec:
           - patch
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - get
+          - update
+        - apiGroups:
           - ramendr.openshift.io
           resources:
           - drclusters

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -213,6 +213,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - ocs.openshift.io
   resources:
   - tlsprofiles

--- a/console/console.go
+++ b/console/console.go
@@ -19,8 +19,10 @@ import (
 
 	consolev1 "github.com/openshift/api/console/v1"
 	apiv1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -65,6 +67,40 @@ func GetService(serviceName string, port int, deploymentNamespace string) apiv1.
 			Selector: map[string]string{
 				serviceLabelKey: PluginName,
 			},
+		},
+	}
+}
+
+func GetNetworkPolicy(deploymentNamespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PluginName,
+			Namespace: deploymentNamespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{serviceLabelKey: PluginName},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"kubernetes.io/metadata.name": "openshift-console",
+					}},
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"app":       "console",
+						"component": "ui",
+					}},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{{
+					Protocol: ptr.To(apiv1.ProtocolTCP),
+					Port:     ptr.To(intstr.FromInt32(9001)),
+				}},
+			}},
+			Egress: []networkingv1.NetworkPolicyEgressRule{},
 		},
 	}
 }

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -4,7 +4,30 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
 )
+
+func TestGetNetworkPolicy(t *testing.T) {
+	policy := GetNetworkPolicy("openshift-operators")
+
+	assert.Equal(t, PluginName, policy.Name)
+	assert.Equal(t, "openshift-operators", policy.Namespace)
+	assert.Equal(t, map[string]string{serviceLabelKey: PluginName}, policy.Spec.PodSelector.MatchLabels)
+	assert.Equal(t, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}, policy.Spec.PolicyTypes)
+	require.Len(t, policy.Spec.Ingress, 1)
+	require.Len(t, policy.Spec.Ingress[0].From, 1)
+	peer := policy.Spec.Ingress[0].From[0]
+	assert.Equal(t, map[string]string{"kubernetes.io/metadata.name": "openshift-console"}, peer.NamespaceSelector.MatchLabels)
+	assert.Equal(t, map[string]string{"app": "console", "component": "ui"}, peer.PodSelector.MatchLabels)
+	require.Len(t, policy.Spec.Ingress[0].Ports, 1)
+	require.NotNil(t, policy.Spec.Ingress[0].Ports[0].Protocol)
+	require.NotNil(t, policy.Spec.Ingress[0].Ports[0].Port)
+	assert.Equal(t, "TCP", string(*policy.Spec.Ingress[0].Ports[0].Protocol))
+	assert.Equal(t, int32(9001), policy.Spec.Ingress[0].Ports[0].Port.IntVal)
+	assert.NotNil(t, policy.Spec.Egress)
+	assert.Empty(t, policy.Spec.Egress)
+}
 
 func TestGetBasePath(t *testing.T) {
 	cases := []struct {

--- a/controllers/clusterversion_controller.go
+++ b/controllers/clusterversion_controller.go
@@ -21,6 +21,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,6 +49,7 @@ type ClusterVersionReconciler struct {
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;update
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;create;update
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=ocs.openshift.io,resources=tlsprofiles,verbs=get;list;watch
@@ -114,12 +116,30 @@ func (r *ClusterVersionReconciler) ensureConsolePlugin(ctx context.Context, clus
 	}
 
 	odfConsolePlugin := console.GetConsolePluginCR(r.ConsolePort, console.PluginName, r.OperatorNamespace)
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &odfConsolePlugin, func() error {
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &odfConsolePlugin, func() error {
 		if odfConsolePlugin.Spec.Backend.Service != nil && odfConsolePlugin.Spec.Backend.Service.BasePath != basePath {
 			r.Logger.Info(fmt.Sprintf("Set the BasePath for odf-multicluster-console plugin as '%s'", basePath))
 			odfConsolePlugin.Spec.Backend.Service.BasePath = basePath
 		}
 		return nil
+	}); err != nil {
+		return err
+	}
+
+	consoleDeployment := &appsv1.Deployment{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: console.PluginName, Namespace: r.OperatorNamespace}, consoleDeployment); err != nil {
+		return err
+	}
+
+	return r.ensureConsoleNetworkPolicy(ctx, consoleDeployment)
+}
+
+func (r *ClusterVersionReconciler) ensureConsoleNetworkPolicy(ctx context.Context, consoleDeployment *appsv1.Deployment) error {
+	networkPolicy := console.GetNetworkPolicy(r.OperatorNamespace)
+	desiredSpec := networkPolicy.Spec
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, networkPolicy, func() error {
+		networkPolicy.Spec = desiredSpec
+		return controllerutil.SetControllerReference(consoleDeployment, networkPolicy, r.Scheme)
 	})
 	return err
 }

--- a/controllers/clusterversion_controller_test.go
+++ b/controllers/clusterversion_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,11 +30,18 @@ func newTestScheme() *runtime.Scheme {
 	utilruntime.Must(consolev1.AddToScheme(s))
 	utilruntime.Must(appsv1.AddToScheme(s))
 	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(networkingv1.AddToScheme(s))
 	utilruntime.Must(ocstlsv1.AddToScheme(s))
 	return s
 }
 
 func newTestReconciler(scheme *runtime.Scheme, objs ...runtime.Object) *ClusterVersionReconciler {
+	consoleDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      console.PluginName,
+		Namespace: testNamespace,
+		UID:       types.UID("console-deployment-uid"),
+	}}
+	objs = append([]runtime.Object{consoleDeployment}, objs...)
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
 	return &ClusterVersionReconciler{
 		Client:            client,
@@ -67,6 +75,37 @@ func TestEnsureConsolePlugin(t *testing.T) {
 			assert.Equal(t, c.expectedBasePath, plugin.Spec.Backend.Service.BasePath)
 		})
 	}
+}
+
+func TestEnsureConsoleNetworkPolicy(t *testing.T) {
+	scheme := newTestScheme()
+	r := newTestReconciler(scheme)
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: console.PluginName, Namespace: testNamespace, UID: types.UID("console-deployment-uid"),
+	}}
+
+	require.NoError(t, r.ensureConsoleNetworkPolicy(context.TODO(), deployment))
+
+	policy := &networkingv1.NetworkPolicy{}
+	key := types.NamespacedName{Name: console.PluginName, Namespace: testNamespace}
+	require.NoError(t, r.Client.Get(context.TODO(), key, policy))
+	require.Len(t, policy.OwnerReferences, 1)
+	assert.Equal(t, "console-deployment-uid", string(policy.OwnerReferences[0].UID))
+	assert.True(t, *policy.OwnerReferences[0].Controller)
+	desiredSpec := console.GetNetworkPolicy(testNamespace).Spec
+	assert.Equal(t, desiredSpec.PodSelector, policy.Spec.PodSelector)
+	assert.Equal(t, desiredSpec.Ingress, policy.Spec.Ingress)
+	assert.Equal(t, desiredSpec.PolicyTypes, policy.Spec.PolicyTypes)
+	assert.Empty(t, policy.Spec.Egress)
+
+	policy.Spec.PolicyTypes = nil
+	require.NoError(t, r.Client.Update(context.TODO(), policy))
+	require.NoError(t, r.ensureConsoleNetworkPolicy(context.TODO(), deployment))
+	require.NoError(t, r.Client.Get(context.TODO(), key, policy))
+	assert.Equal(t, desiredSpec.PodSelector, policy.Spec.PodSelector)
+	assert.Equal(t, desiredSpec.Ingress, policy.Spec.Ingress)
+	assert.Equal(t, desiredSpec.PolicyTypes, policy.Spec.PolicyTypes)
+	assert.Empty(t, policy.Spec.Egress)
 }
 
 func TestEnsureConsolePluginUpdatesBasePath(t *testing.T) {


### PR DESCRIPTION
## Summary
- reconcile the Multicluster Console NetworkPolicy with its Deployment
- restrict TCP/9001 ingress to OpenShift Console UI pods
- deny console pod egress; proxy traffic originates from OpenShift Console


## Coordination
Part of the coordinated ODF, Client Console, and Multicluster Console NetworkPolicy change.

- red-hat-storage/odf-operator#896
- red-hat-storage/ocs-client-operator#708
